### PR TITLE
32bit support for timer interrupt 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,7 @@ all: baremetal/hello_sifive_u \
 	baremetal/fib_sifive_e \
 	baremetal/hello_sifive_e32 \
 	baremetal/fib_sifive_e32
+baremetal: all
 
 # Shortcuts
 run32: run-baremetal32
@@ -167,10 +168,6 @@ linux:
 .PHONY: initrd
 initrd:
 	./scripts/build-initrd.sh
-
-.PHONY: baremetal
-baremetal:
-	./scripts/build-baremetal.sh
 
 .PHONY: elf
 elf:

--- a/baremetal-hello.s
+++ b/baremetal-hello.s
@@ -102,9 +102,8 @@ _start:
         li      a0, (5*ONE_SECOND)      # a0 = 5sec
         jal     set_timer_for_current_hart
 
-                                        # enable interrupts by setting required values to mstatus, mtvec and mie:
-        li      t0, 0x8                 # make a mask for 3rd bit
-        csrs    mstatus, t0             # set MIE (M-mode Interrupts Enabled) bit in mstatus reg
+                                        # enable interrupts by setting required values to mstatus, mtvec and mie: 
+        csrsi   mstatus, 0x8            # set MIE (M-mode Interrupts Enabled) = 3rd bit (0x08 mask) in mstatus CSR
 
                                         # store trap_vector to tvec, but first increment it by 1. This will set
                                         # the mode bits to 1, which means vectored mode, in which exceptions
@@ -114,7 +113,7 @@ _start:
         csrw    mtvec, t0
 
         li      t0, 0x80                # mask for 7th bit
-        csrs    mie, t0                 # set MTIE (M-mode Timer Interrupt Enabled) bit
+        csrs    mie, t0                 # set MTIE (M-mode Timer Interrupt Enabled) in mie CSR
 
 
 2:      la      t0, current_hart

--- a/baremetal-hello.s
+++ b/baremetal-hello.s
@@ -1,14 +1,15 @@
 .include "machine-word.inc"
 .equ STACK_PER_HART,    64 * REGBYTES
 
-# These addresses are taken from the SiFive E31 core manual[1], Chapter 8: Core
-# Local Interruptor (CLINT)
+# These addresses are taken from the SiFive E31 core manual [1],
+# Chapter 8: Core Local Interruptor (CLINT)
 # [1] https://static.dev.sifive.com/E31-RISCVCoreIP.pdf
-.equ MTIME, 0x200bff8
-.equ MTIMECMP, 0x2004000
+.equ MTIME,             0x200bff8
+.equ MTIMECMP_BASE,     0x2004000
 
-# This was determined experimentally:
-.equ ONE_SECOND, 10000000
+# Based on SIFIVE_CLINT_TIMEBASE_FREQ = 10000000 value from QEMU SiFive CLINT implementation [2],
+# [2] https://github.com/qemu/qemu/blob/master/include/hw/intc/sifive_clint.h
+.equ ONE_SECOND,        10000000
 
 .balign 4
 .section .text
@@ -38,33 +39,6 @@ _start:
 1:      la      t0, current_hart
         lx      t0, 0,(t0)
         bne     t0, s2, 1b
-
-# NB: only do timer in RV64 for now, will do RV32 later
-.ifdef RISCV64
-        # Set the timer: read current time from mtime, add delta time to it,
-        # and write the result to mtimecmp:
-        li      t2, MTIME
-        ld      t2, 0(t2)               # read from mtime mmapped register
-        li      t4, (5*ONE_SECOND)      # t4 = 5s, use a register because the value is too big for immediate instruction
-        add     t2, t2, t4              # t2 = mtime + 5s
-        li      t3, MTIMECMP
-        sd      t2, 0(t3)               # write t2 to mtimecmp
-
-
-        # Enable interrupts by setting required values to mstatus, mtvec and mie:
-        li      t0, 0x8                 # make a mask for 3rd bit
-        csrrs   t1, mstatus, t0         # set MIE (M-mode Interrupts Enabled) bit in mstatus reg
-
-        # store trap_vector to tvec, but first increment it by 1. This will set
-        # the mode bits to 1, which means vectored mode, in which exceptions
-        # jump to trap_vector+4*cause.
-        la      t0, trap_vector
-        addi    t0, t0, 1
-        csrrw   t1, mtvec, t0
-
-        li      t0, 0x80                # mask for 7th bit
-        csrrs   t1, mie, t0             # set MTIE (M-mode Timer Interrupt Enabled) bit
-.endif
 
         # print registers
         stackalloc_x 19                 # allocate 19 register size arguments on stack
@@ -96,37 +70,52 @@ _start:
         call    printf
         stackfree_x 19
 
-                                        # print symbols, but only on the 1st hart
+
+                                        # print symbols, CSRs and setup timer, but only on the 1st hart
         bnez    s2, 2f
         la      a0, print_symbols_str
         la      a1, print_symbols_arg
         call    printf
 
-        # print M-mode registers, also only on the 1st hart
+                                        # print M-mode CSR registers
         stackalloc_x 5                  # allocate 5 register size arguments on stack
         sx      s2, 0,(sp)              # s2 contains mhartid
         csrr    t2, misa                # read misa (Machine ISA Register)
         sx      t2, 1,(sp)
         csrr    t2, mstatus             # read mstatus
         sx      t2, 2,(sp)
-.ifdef RISCV64
         li      t2, MTIME
-        ld      t2, 0(t2)               # read from mtime mmapped register
-.else
-        li      t2, 0
-.endif
+        lx      t2, 0,(t2)              # read from memory-mapped mtime register, @TODO: support 64bit in RV32
         sx      t2, 3,(sp)
-.ifdef RISCV64
-        li      t2, MTIMECMP
-        ld      t2, 0(t2)               # read from mtimecmp mmapped register
-.else
-        li      t2, 0
-.endif
+        li      t2, MTIMECMP_BASE
+        csrr    t3, mhartid
+        slli    t3, t3, 3
+        add     t2, t2, t3              # mtimecmp += 8 * mhartid
+        lx      t2, 0,(t2)              # read from memory-mapped mtimecmp_x64bit[mhartid] @TODO: support 64bit in RV32
         sx      t2, 4,(sp)
         la      a0, print_mregs_str
         mv      a1, sp
         call    printf
         stackfree_x 5
+
+                                        # setup timer & enable interrupts
+        li      a0, (5*ONE_SECOND)      # a0 = 5sec
+        jal     set_timer_for_current_hart
+
+                                        # enable interrupts by setting required values to mstatus, mtvec and mie:
+        li      t0, 0x8                 # make a mask for 3rd bit
+        csrrs   t1, mstatus, t0         # set MIE (M-mode Interrupts Enabled) bit in mstatus reg
+
+                                        # store trap_vector to tvec, but first increment it by 1. This will set
+                                        # the mode bits to 1, which means vectored mode, in which exceptions
+                                        # jump to trap_vector+4*cause.
+        la      t0, trap_vector
+        addi    t0, t0, 1
+        csrrw   t1, mtvec, t0
+
+        li      t0, 0x80                # mask for 7th bit
+        csrrs   t1, mie, t0             # set MTIE (M-mode Timer Interrupt Enabled) bit
+
 
 2:      la      t0, current_hart
         addi    t1, s2, 1
@@ -137,52 +126,89 @@ park:
         j       park
 
 trap_vector:
-        j noop_handler            # offs  0: user software interrupt
-        j noop_handler            # offs  4: supervisor software interrupt
-        j noop_handler            # offs  8: reserved
-        j noop_handler            # offs  c: machine software interrupt
-        j noop_handler            # offs 10: user timer interrupt
-        j noop_handler            # offs 14: supervisor timer interrupt
-        j noop_handler            # offs 18: reserved
-        j timer_handler           # offs 1c: machine timer interrupt
+        j noop_handler                  # offs  0: user software interrupt
+        j noop_handler                  # offs  4: supervisor software interrupt
+        j noop_handler                  # offs  8: reserved
+        j noop_handler                  # offs  c: machine software interrupt
+        j noop_handler                  # offs 10: user timer interrupt
+        j noop_handler                  # offs 14: supervisor timer interrupt
+        j noop_handler                  # offs 18: reserved
+        j timer_handler                 # offs 1c: machine timer interrupt
 
 noop_handler:
         mret
 
 timer_handler:
-# NB: only do timer in RV64 for now, will do RV32 later
-.ifdef RISCV64
         # print a few interesting registers from the timer handler
-        stackalloc_x 6                  # allocate 6 register size arguments on stack
-        csrr    t2, mcause
+        stackalloc_x 7                  # allocate 7 register size arguments on stack
+        csrr    t2, mhartid
         sx      t2, 0,(sp)
-        csrr    t2, mepc
+        csrr    t2, mcause
         sx      t2, 1,(sp)
-        csrr    t2, mtval
+        csrr    t2, mepc
         sx      t2, 2,(sp)
-        csrr    t2, mstatus
+        csrr    t2, mtval
         sx      t2, 3,(sp)
-        li      t2, MTIME
-        ld      t2, 0(t2)
+        csrr    t2, mstatus
         sx      t2, 4,(sp)
-        li      t2, MTIMECMP
-        ld      t2, 0(t2)
+        li      t2, MTIME               # read from memory-mapped mtime register, @TODO: support 64bit in RV32
+        lx      t2, 0,(t2)
         sx      t2, 5,(sp)
+        li      t2, MTIMECMP_BASE
+        csrr    t3, mhartid
+        slli    t3, t3, 3
+        add     t2, t2, t3              # mtimecmp += 8 * mhartid
+        lx      t2, 0,(t2)              # read from memory-mapped mtimecmp_x64bit[mhartid] @TODO: support 64bit in RV32
+        sx      t2, 6,(sp)
         la      a0, print_timer_str
         mv      a1, sp
         call    printf
         stackfree_x 6
 
-        # now reset the timer for the future again:
-        li      t2, MTIME
-        ld      t2, 0(t2)
-        li      t4, (3*ONE_SECOND)      # t4 = 3s
-        add     t2, t2, t4              # t2 = mtime + 3s
-        li      t3, MTIMECMP
-        sd      t2, 0(t3)               # write t2 to mtimecmp
-.endif
+        li      a0, (3*ONE_SECOND)      # a0 = 3s
+        jal     set_timer_for_current_hart
+
         # return from the handler
         mret
+
+
+set_timer_for_current_hart:             # Set the timer: read current time from mtime, add delta time to it,
+                                        # and write the result to mtimecmp of current hart:
+                                        #       mtimecmp[mhartid] = mtime + delta_time
+                                        # @param[in] a0 delta_time
+
+        li      t5, MTIME
+        li      t6, MTIMECMP_BASE
+        csrr    t0, mhartid
+        slli    t0, t0, 3
+        add     t6, t6, t0              # mtimecmp += 8 * mhartid
+
+.ifdef RISCV64
+        ld      t0, 0(t5)               # read from mtime memory-mapped register
+        add     t0, t0, a0              # t2 = mtime + 5sec
+        sd      t0, 0(t6)               # write t2 to mtimecmp
+.else
+        lw      t0, 0(t5)               # read from mtime memory-mapped into t0:t1 pair
+        lw      t1, 4(t5)
+        li      t2, (5*ONE_SECOND)      # t2 = 5sec
+
+                                        # add and write t1:t0 + t2 => t1:t4 into mtimecmp
+
+                                        # unsigned int overlow detection based on example from RISC-V ISA section Integer Computational Instructions:
+                                        #     add t0, t1, t2; bltu t0, t1, overflow.
+        add     t4, t0, t2
+        bgeu    t4, t0, 1f              # bgeu == !bltu
+        addi    t1, t1, 1               # handle overflow
+1:
+                                        # mtimecmp write in RV32 based on example from RISC-V Priveleged ISA section Machine Timer Registers:
+                                        #     li t0, -1; sw t0, mtimecmp; sw a1, mtimecmp+4; sw a0, mtimecmp.
+        li      t0, -1
+        sw      t0, 0(t6)               # 1) write unsigned (-1) into low 32bits of mtimecmp = no smaller than old value
+        sw      t1, 4(t6)               # 1) write                 high 32bits into mtimecmp = no smaller than new value
+        sw      t4, 0(t6)               # 1) write                  low 32bits into mtimecmp = new value
+.endif
+        ret
+
 
 .section .rodata
 rodata_start:
@@ -191,9 +217,9 @@ print_registers_str:
 print_symbols_str:
         .string "Symbols: _start=%p rodata_start=%p data_start=%p printf=%p this-str=%p stack_top=%p _end=%p\n"
 print_mregs_str:
-        .string "\nM-mode registers: mhartid=%p misa=%p mstatus=%p mtime=%p mtimecmp=%p\n"
+        .string "Machine CSRs: mhartid=%p misa=%p mstatus=%p mtime=%p mtimecmp=%p\n"
 print_timer_str:
-        .string "\nHullo from timer! mcause=%p mepc=%p mtval=%p mstatus=%p mtime=%p mtimecmp=%p\n"
+        .string "\nHullo from timer! mhartid=%p mcause=%p mepc=%p mtval=%p mstatus=%p mtime=%p mtimecmp=%p\n"
 print_symbols_arg:
         pointer _start
         pointer rodata_start

--- a/baremetal-hello.s
+++ b/baremetal-hello.s
@@ -162,7 +162,7 @@ timer_handler:
         la      a0, print_timer_str
         mv      a1, sp
         call    printf
-        stackfree_x 6
+        stackfree_x 7
 
         li      a0, (3*ONE_SECOND)      # a0 = 3s
         jal     set_timer_for_current_hart

--- a/baremetal-hello.s
+++ b/baremetal-hello.s
@@ -104,17 +104,17 @@ _start:
 
                                         # enable interrupts by setting required values to mstatus, mtvec and mie:
         li      t0, 0x8                 # make a mask for 3rd bit
-        csrrs   t1, mstatus, t0         # set MIE (M-mode Interrupts Enabled) bit in mstatus reg
+        csrs    mstatus, t0             # set MIE (M-mode Interrupts Enabled) bit in mstatus reg
 
                                         # store trap_vector to tvec, but first increment it by 1. This will set
                                         # the mode bits to 1, which means vectored mode, in which exceptions
                                         # jump to trap_vector+4*cause.
         la      t0, trap_vector
         addi    t0, t0, 1
-        csrrw   t1, mtvec, t0
+        csrw    mtvec, t0
 
         li      t0, 0x80                # mask for 7th bit
-        csrrs   t1, mie, t0             # set MTIE (M-mode Timer Interrupt Enabled) bit
+        csrs    mie, t0                 # set MTIE (M-mode Timer Interrupt Enabled) bit
 
 
 2:      la      t0, current_hart


### PR DESCRIPTION
* Extracted timer setup into set_timer_for_current_hart function. Implemented 64bit unsigned addition for RV32.
* Multiple hardware threads are supported by treating mtimercmp as an array, each element corresponds to separate hart.
* Shorter pseudo-instructions CSRS, CSRSI and immediate when possible
* ONE_SECOND actually comes from sifive_clint.h setup.