### PR TITLE
Memory protection

### DIFF
--- a/baremetal-user.s
+++ b/baremetal-user.s
@@ -498,28 +498,3 @@ msg_exception:
         .string "Exception occured, mcause:%p mepc:%p mtval:%p (user payload at:%p, stack top:%p).\n"
 
 .section .data
-
-### CHECK if USER mode is supported
-#   https://github.com/riscv/riscv-tests/blob/master/isa/rv64si/csr.S
-
-#   # For RV64, make sure UXL encodes RV64.  (UXL does not exist for RV32.)
-# #if __riscv_xlen == 64
-#   # If running in M mode, use mstatus.MPP to check existence of U mode.
-#   # Otherwise, if in S mode, then U mode must exist and we don't need to check.
-# #ifdef __MACHINE_MODE
-#   li t0, MSTATUS_MPP
-#   csrc mstatus, t0
-#   csrr t1, mstatus
-#   and t0, t0, t1
-#   bnez t0, 1f
-# #endif
-#   # If U mode is present, UXL should be 2 (XLEN = 64-bit)
-#   TEST_CASE(18, a0, SSTATUS_UXL & (SSTATUS_UXL << 1), csrr a0, sstatus; li a1, SSTATUS_UXL; and a0, a0, a1)
-# #ifdef __MACHINE_MODE
-#   j 2f
-# 1:
-#   # If U mode is not present, UXL should be 0
-#   TEST_CASE(19, a0, 0, csrr a0, sstatus; li a1, SSTATUS_UXL; and a0, a0, a1)
-# 2:
-# #endif
-# #endif

--- a/baremetal-user.s
+++ b/baremetal-user.s
@@ -1,10 +1,6 @@
 .include "machine-word.inc"
 .equ STACK_PER_HART,    64 * REGBYTES
-
-.macro  syscall nr
-        li      a7, \nr                 # for fun let's pretend syscall is kinda like Linux: syscall nr in a7, other arguments in a0..a6
-        ecall
-.endm
+.equ HALT_ON_EXCEPTION, 0
 
 .balign 4
 .section .text
@@ -17,8 +13,8 @@ _start:
 
                                         # from: sifive-interrupt-cookbook-v1p2.pdf
                                         # 2.1.3 Early Boot: Setup mtvec Register
-        csrwi   mie, 0                  # It is recommended to disable interrupts globally using mstatus.mie prior to changing mtvec.
-                                        # For sanity's sake we set up an early trap vector that just does nothing.
+        csrwi   mie, 0                  # > It is recommended to disable interrupts globally using mstatus.mie prior to changing mtvec.
+                                        # > For sanity's sake we set up an early trap vector that just does nothing.
         la      t0, early_trap_vector
         csrw    mtvec, t0
 
@@ -29,20 +25,20 @@ _start:
                                         # @TODO: setup Global Pointer
 
                                         # from: https://github.com/sifive/freedom-metal/master/src/entry.S & metal.ramrodata.lds
-                                        # The absolute first thing that must happen is configuring the global
-                                        # pointer register, which must be done with relaxation disabled because
-                                        # it's not valid to obtain the address of any symbol without GP configured.
-                                        #       . = ALIGN(8);
-                                        #       PROVIDE( __global_pointer$ = . + 0x800 );
-                                        #       *(.sdata .sdata.* .sdata2.*)
+                                        # > The absolute first thing that must happen is configuring the global
+                                        # > pointer register, which must be done with relaxation disabled because
+                                        # > it's not valid to obtain the address of any symbol without GP configured.
+                                        # >       . = ALIGN(8);
+                                        # >       PROVIDE( __global_pointer$ = . + 0x800 );
+                                        # >       *(.sdata .sdata.* .sdata2.*)
 
                                         # from: https://gnu-mcu-eclipse.github.io/arch/riscv/programmer/
-                                        # The gp (Global Pointer) register is a solution to further optimise memory accesses within a single 4KB region.
-                                        # The region size is 4K because RISC-V immediate values are 12-bit signed values,
-                                        # since the values are signed, the __global_pointer$ must point to the middle of the region.
-                                        #       PROVIDE( __global_pointer$ = . + (4K / 2) );
-                                        #       *(.sdata .sdata.*)
-        # .option push                  # requires that we disable linker relaxations (or it will be relaxed to `mv gp, gp`).
+                                        # > The gp (Global Pointer) register is a solution to further optimise memory accesses within a single 4KB region.
+                                        # > The region size is 4K because RISC-V immediate values are 12-bit signed values,
+                                        # > since the values are signed, the __global_pointer$ must point to the middle of the region.
+                                        # >       PROVIDE( __global_pointer$ = . + (4K / 2) );
+                                        # >       *(.sdata .sdata.*)
+        # .option push                  # > requires that we disable linker relaxations (or it will be relaxed to `mv gp, gp`).
         # .option norelax
         # la  gp, __global_pointer$
         # .option pop
@@ -67,13 +63,13 @@ single_core:                            # only the 1st hart past this point
         # sub     sp, sp, t0            # sp -= stack_size * hart_id
 
                                         # 3.1.12 Machine Trap-Vector Base-Address Register (mtvec)
-                                        # When MODE=Vectored, all synchronous exceptions into machine mode cause
-                                        # the pc to be set to the address in the BASE field, whereas interrupts cause
-                                        # the pc to be set to the address in the BASE field plus four times the interrupt cause number.
-                                        # When vectored interrupts are enabled, interrupt cause 0, which corresponds to user-mode
-                                        # software interrupts, are vectored to the same location as synchronous exceptions.
-                                        # This ambiguity does not arise in practice, since user-mode software interrupts are
-                                        # either disabled or delegated to a less-privileged mode.
+                                        # > When MODE=Vectored, all synchronous exceptions into machine mode cause
+                                        # > the pc to be set to the address in the BASE field, whereas interrupts cause
+                                        # > the pc to be set to the address in the BASE field plus four times the interrupt cause number.
+                                        # > When vectored interrupts are enabled, interrupt cause 0, which corresponds to user-mode
+                                        # > software interrupts, are vectored to the same location as synchronous exceptions.
+                                        # > This ambiguity does not arise in practice, since user-mode software interrupts are
+                                        # > either disabled or delegated to a less-privileged mode.
 
 
                                         # set up exception, interrupt & syscall trap vector
@@ -84,23 +80,89 @@ single_core:                            # only the 1st hart past this point
         ori     t0, t0, 0b01            # mtvec.mode |= 0b01; trap_vector in t0 is 4 byte aligned, last two bits are zero
         csrw    mtvec, t0
 
-                                        # @TODO: setup physical memory protection (PMP) for user mode
-                                        # 3.6 Physical Memory Protection
+                                        # 3.6.1 Physical Memory Protection CSRs
+                                        # > PMP entries are described by an 8-bit configuration register AND one XLEN-bit address register.
+                                        # > The PMP configuration registers are densely packed into CSRs to minimize context-switch time.
+                                        # >
+                                        # > For RV32, pmpcfg0..pmpcfg3, hold the configurations pmp0cfg..pmp15cfg for the 16 PMP entries.
+                                        # > For RV64, pmpcfg0 and pmpcfg2 hold the configurations for the 16 PMP entries; pmpcfg1 and pmpcfg3 are illegal.
+                                        # > For RV32, each PMP address register encodes bits 33:2 of a 34-bit physical address.
+                                        # > For RV64, each PMP address register encodes bits 55:2 of a 56-bit physical address.
+                                        # >
+                                        # > The R, W, and X bits, when set, indicate that the PMP entry permits read, write, and instruction execution.
+                                        # >
+                                        # > If PMP entry i's A field is set to TOR, the associated address register forms the top of the address range,
+                                        # > the entry matches any address a such that pmpaddr[i-1] <= a < pmpaddr[i]. If PMP entry 0's A field
+                                        # > is set to TOR, zero is used for the lower bound, and so it matches any address a < pmpaddr0.
+                                        # >
+                                        # > PMP entries are statically prioritized. The lowest-numbered PMP entry that matches any byte
+                                        # > of an access determines whether that access succeeds or fails.
 
-        la      a0, print_m_hello_str   # DEBUG print
+                                        # define 4 memory address ranges for Physical Memory Protection
+                                        # 0 :: [0 .. user_payload]
+                                        # 1 :: [user_payload .. user_payload_end]
+                                        # 2 :: [user_payload_end .. stack_bottom]
+                                        # 3 :: [stack_bottom .. stack_top]
+        la      t0, user_payload
+        la      t1, user_payload_end
+        la      t2, stack_bottom
+        la      t3, stack_top
+        srli    t0, t0, 2               # store only the highest [XLEN-2:2] bits of the address in the PMP address register
+        srli    t1, t1, 2               # as required by specification in 3.6.1 Physical Memory Protection CSRs
+        srli    t2, t2, 2
+        srli    t3, t3, 2
+        csrw    pmpaddr0, t0
+        csrw    pmpaddr1, t1
+        csrw    pmpaddr2, t2
+        csrw    pmpaddr3, t3
+
+                                        # set 4 PMP entries to TOR (Top Of the address Range) addressing mode so that the associated
+                                        # address register forms the top of the address range per entry,
+                                        # the type of PMP entry is encoded in 2 bits: OFF = 0, TOR = 1, NA4 = 2, NAPOT = 3
+                                        # and stored in 3:4 bits of every PMP entry
+
+                                        # 3.6.1 Physical Memory Protection CSRs
+        .equ PMP_LOCK,  (1<<7)
+        .equ PMP_NAPOT, (3<<3)          # Address Mode: Naturally aligned power-of-two region, >=8 bytes
+        .equ PMP_NA4,   (2<<3)          # Address Mode: Naturally aligned four-byte region
+        .equ PMP_TOR,   (1<<3)          # Address Mode: Top of range, address register forms the top of the address range,
+                                        # such that PMP entry i matches any a address that pmpaddr[i-1] <= a < pmpaddr[i]
+        .equ PMP_X,     (1<<2)          # Access Mode: Executable
+        .equ PMP_W,     (1<<1)          # Access Mode: Writable
+        .equ PMP_R,     (1<<0)          # Access Mode: Readable
+        .equ PMP_0,     (1<<0)          # [0..8]   1st PMP entry in pmpcfgX register
+        .equ PMP_1,     (1<<8)          # [8..16]  2nd PMP entry in pmpcfgX register
+        .equ PMP_2,     (1<<16)         # [16..24] 3rd PMP entry in pmpcfgX register
+        .equ PMP_3,     (1<<24)         # [24..32] 4th PMP entry in pmpcfgX register
+
+        li      t0, PMP_TOR*(PMP_0|PMP_1|PMP_2|PMP_3)
+
+                                        # set access flags for 4 PMP entries:
+                                        # 0 :: [0 .. user_payload]                      000  M-mode kernel code, no access in U-mode
+                                        # 1 :: [user_payload .. user_payload_end]       X0R  user code, executable, non-modifiable in U-mode
+                                        # 2 :: [user_payload_end .. stack_bottom]       000  no access in U-mode
+                                        # 3 :: [stack_bottom .. stack_top]              0WR  user stack, modifiable, but no executable in U-mode
+                                        # access (R)ead, (W)rite and e(X)ecute are 1 bit flags and stored in 0:2 bits of every PMP entry
+        li      t1, (PMP_X|PMP_R)*PMP_1 | (PMP_W|PMP_R)*PMP_3
+
+        or      t0, t0, t1              # combine addressing modes and access flags into the single packed configuration register
+        csrw    pmpcfg0, t0             # pmpcfg0 = PMPs.AddressMode | PMPs.XWR; pmpcfg0 contains at least 4 (8 in RV64) first PMP entries
+
+
+        la      a0, msg_m_hello         # DEBUG print
         call    printf                  # DEBUG print
 
                                         # 3.1.7 Privilege and Global Interrupt-Enable Stack in mstatus register
-                                        # The MRET, SRET, or URET instructions are used to return from traps in M-mode, S-mode, or U-mode respectively.
-                                        # When executing an xRET instruction, supposing x PP holds the value y, x IE is set to xPIE;
-                                        # the privilege mode is changed to y; xPIE is set to 1; and xPP is set to U (or M if user-mode is not supported).
+                                        # > The MRET, SRET, or URET instructions are used to return from traps in M-mode, S-mode, or U-mode respectively.
+                                        # > When executing an xRET instruction, supposing x PP holds the value y, x IE is set to xPIE;
+                                        # > the privilege mode is changed to y; xPIE is set to 1; and xPP is set to U (or M if user-mode is not supported).
 
                                         # 3.2.2 Trap-Return Instructions
-                                        # An xRET instruction can be executed in privilege mode x or higher,
-                                        # where executing a lower-privilege xRET instruction will pop
-                                        # the relevant lower-privilege interrupt enable and privilege mode stack.
-                                        # In addition to manipulating the privilege stack as described in Section 3.1.7,
-                                        # xRET sets the pc to the value stored in the x epc register.
+                                        # > An xRET instruction can be executed in privilege mode x or higher,
+                                        # > where executing a lower-privilege xRET instruction will pop
+                                        # > the relevant lower-privilege interrupt enable and privilege mode stack.
+                                        # > In addition to manipulating the privilege stack as described in Section 3.1.7,
+                                        # > xRET sets the pc to the value stored in the x epc register.
 
                                         # switch from Machine to User mode:
                                         # set Machine Previous Privelege to User -> mstatus.mpp = User
@@ -123,8 +185,8 @@ single_core:                            # only the 1st hart past this point
 #
                                         # from: sifive-interrupt-cookbook-v1p2.pdf
                                         # 2.1.3 Early Boot: Setup mtvec Register
-                                        # For sanity's sake we set up an early trap vector that just does nothing.
-                                        # If you end up here then there's a bug in the early boot code somewhere.
+                                        # > For sanity's sake we set up an early trap vector that just does nothing.
+                                        # > If you end up here then there's a bug in the early boot code somewhere.
 early_trap_vector:
 1:      csrr    t0, mcause
         csrr    t1, mepc
@@ -132,36 +194,36 @@ early_trap_vector:
         j       1b                      # loop indefinitely
 
                                         # 3.1.12 Machine Trap-Vector Base-Address Register (mtvec)
-                                        # When MODE=Vectored, all synchronous exceptions into machine mode cause
-                                        # the pc to be set to the address in the BASE field, whereas interrupts cause
-                                        # the pc to be set to the address in the BASE field plus four times the interrupt cause number.
-                                        # 
-                                        # When vectored interrupts are enabled, interrupt cause 0, which corresponds to user-mode
-                                        # software interrupts, are vectored to the same location as synchronous exceptions.
-                                        # This ambiguity does not arise in practice, since user-mode software interrupts are
-                                        # either disabled or delegated to a less-privileged mode.
+                                        # > When MODE=Vectored, all synchronous exceptions into machine mode cause
+                                        # > the pc to be set to the address in the BASE field, whereas interrupts cause
+                                        # > the pc to be set to the address in the BASE field plus four times the interrupt cause number.
+                                        # >
+                                        # > When vectored interrupts are enabled, interrupt cause 0, which corresponds to user-mode
+                                        # > software interrupts, are vectored to the same location as synchronous exceptions.
+                                        # > This ambiguity does not arise in practice, since user-mode software interrupts are
+                                        # > either disabled or delegated to a less-privileged mode.
 
 
                                         # from: https://stackoverflow.com/questions/58726942/risc-v-exceptions-vs-interrupts
                                         # @TODO: figure out correct section as stackoverflow answer does not match the v1.10 document anymore :(
-                                        # Section 3.1.15 of the privileged RISC-V specification:
-                                        # when an interrupt is raised MEPC points to the first uncompleted instruction AND
-                                        # when an exception is raised MEPC points to the instruction that raised an exception.
-                                        #
-                                        # Section 1.6 of the unprivileged RISC-V specification defines that:
-                                        # a) exceptions are raised by instructions and
-                                        # b) interrupts are raised by external events.
-                                        #
-                                        # When an (synchronous) exception is raised, the triggering instruction cannot be completed properly.
-                                        # Hence, there are two possibilities for the return address: either the instruction itself or
-                                        # the following instruction. Both solutions make sense. If it points to the instruction itself
-                                        # it is easier to determine the problem and react accordingly. If it points to the next instruction,
-                                        # the address need not be incremented when returning from the exception handler.
-                                        # 
-                                        # (Asynchronous) interrupts are different, they break the stream of executed instructions of
-                                        # an independent thread. Therefore, there is only one reasonable solution for the return address:
-                                        # the first instruction that has not completed yet. Thus, when returning from the interrupt handler,
-                                        # the execution continues exactly where it was interrupted.
+                                        # > Section 3.1.15 of the privileged RISC-V specification:
+                                        # > when an interrupt is raised MEPC points to the first uncompleted instruction AND
+                                        # > when an exception is raised MEPC points to the instruction that raised an exception.
+                                        # >
+                                        # > Section 1.6 of the unprivileged RISC-V specification defines that:
+                                        # > a) exceptions are raised by instructions and
+                                        # > b) interrupts are raised by external events.
+                                        # >
+                                        # > When an (synchronous) exception is raised, the triggering instruction cannot be completed properly.
+                                        # > Hence, there are two possibilities for the return address: either the instruction itself or
+                                        # > the following instruction. Both solutions make sense. If it points to the instruction itself
+                                        # > it is easier to determine the problem and react accordingly. If it points to the next instruction,
+                                        # > the address need not be incremented when returning from the exception handler.
+                                        # >
+                                        # > (Asynchronous) interrupts are different, they break the stream of executed instructions of
+                                        # > an independent thread. Therefore, there is only one reasonable solution for the return address:
+                                        # > the first instruction that has not completed yet. Thus, when returning from the interrupt handler,
+                                        # > the execution continues exactly where it was interrupted.
 trap_vector:                            # 3.1.20 Machine Cause Register (mcause), Table 3.6: Machine cause register (mcause) values after trap.
         j exception_dispatch            #  0: user software interrupt OR _exception_ (See note in 3.1.12: Machine Trap-Vector Base-Address Register)
         j interrupt_noop                #  1: supervisor software interrupt
@@ -228,6 +290,9 @@ syscall_dispatch:                       # a7 contains syscall index
         jr      t0
 
 exception_epilogue:
+.if HALT_ON_EXCEPTION == 1
+1:      j       1b
+.endif
 syscall_epilogue:
         csrr    t0, mepc                # mepc points to the instruction that raised an exception
         addi    t0, t0, 4               # move mepc by the size of a single RISC-V instruction (always 4 bytes in RV32, RV64, RV128)
@@ -240,6 +305,7 @@ syscall_epilogue:
 
 interrupt_epilogue:
         mret
+
 
 ### Exception, Interrupt & Syscall Handlers ###################################
 #
@@ -267,16 +333,18 @@ exception:
         csrr    t0, mcause
         csrr    t1, mepc
         csrr    t2, mtval
-        la      t3, user_entry_point
-        stackalloc_x 4
+        la      t3, user_payload
+        la      t4, stack_top
+        stackalloc_x 5
         sx      t0, 0, (sp)
         sx      t1, 1, (sp)
         sx      t2, 2, (sp)
         sx      t3, 3, (sp)
-        la      a0, print_exception_str
+        sx      t4, 4, (sp)
+        la      a0, msg_exception
         mv      a1, sp
         call    printf
-        stackfree_x 4
+        stackfree_x 5
 
         lx      x1,   1, (sp)           # ra :: x1
         lx      x7,   7, (sp)           # t2 :: x7
@@ -308,32 +376,118 @@ syscall4:
         jal     prints
         j       syscall_epilogue
 
+test_func:
+        ret
 
-### User mode code ############################################################
+
+### User payload = code + readonly data for U-mode ############################
 #
+.macro  syscall nr
+        li      a7, \nr                 # for fun let's pretend syscall is kinda like Linux: syscall nr in a7, other arguments in a0..a6
+        ecall
+.endm
+.macro  sys_print addr
+        la      a0, \addr
+        syscall 4
+.endm
 
+.balign 4096                            # at least in QEMU memory protection works on 4KiB page boundaries
+                                        # align user payload part on 4KiB to make the further experiments more predicatble
+user_payload:
 user_entry_point:
-        la      a0, print_u_hello_str
-        syscall 4                       # 4 :: prints syscall
+        nop                             # no-operation instructions here help to distinguish between
+        nop                             # illegal instruction -vs- page fault due to missing e(X)ecute access flag
+        nop                             #
+        nop                             # 4 nops instead of one, to align the code below on 0x10
+                                        # which makes instruction address easier to follow in case of an exception
 
+        sys_print msg_u_hello
+
+        sys_print msg_read_user_csr
+        csrr    a0, cycle
+        sys_print msg_ok
+
+        sys_print msg_load_from_user_mem
+        la      a0, msg_u_hello
+        lb      t0, 0(a0)
+        lx      t0, 0,(a0)
+        sys_print msg_ok
+
+#         li      a0, 0x7FFFF000
+#         li      a1, 0x80010000
+# 1:      lx      t0, 0,(a0)
+#         addi    a0, a0, 0x100
+#         blt     a0, a1, 1b
+
+        sys_print msg_stack_access
+        stackalloc_x 2
+        lx      t0, 0,(sp)
+        lx      t1, 1,(sp)
+        sx      t0, 0,(sp)
+        sx      t1, 1,(sp)
+        stackfree_x 2
+        sys_print msg_ok
+
+        sys_print msg_read_unaligned_mem
+        la      a0, msg_u_hello
+        lw      t0, 1(a0)
+        sys_print msg_ok
+
+        sys_print msg_write_to_readonly_mem
+        la      a0, user_entry_point
+        sx      t0, 0,(a0)
+        sys_print msg_ok
+
+        sys_print msg_read_protected_csr
         csrr    a0, mhartid             # causes Illegal instruction (mcause=2) in User mode
 
-        la      a0, print_u_hello_str
-        call    printf
+        sys_print msg_load_from_protected_mem
+        la      a0, msg_m_hello
+        lx      t0, 0,(a0)
+
+        sys_print msg_done
 
 1:      wfi                             # park hart waiting for interrupt
         j       1b
+
+msg_u_hello:
+        .string "Hello from U-mode!\n"
+
+msg_read_user_csr:
+        .string "Read user CSR: "
+msg_load_from_user_mem:
+        .string "Read from memory: "
+msg_stack_access:
+        .string "Read/write stack: "
+msg_read_unaligned_mem:
+        .string "Read from unaligned memory:  "
+msg_write_to_readonly_mem:
+        .string "Illegal write to read-only memory: "
+msg_read_protected_csr:
+        .string "Illegal read from protected CSR: "
+msg_load_from_protected_mem:
+        .string "Illegal read from protected memory: "
+msg_call_printf:
+        .string "Illegal call to function in protected memory: "
+msg_done:
+        .string "Done.\n"
+msg_pass:
+        .string "?\n"
+msg_ok:
+        .string "OK\n"
+
+user_payload_end:
+.balign 4096
+
 
 ### Data ######################################################################
 #
 
 .section .rodata
-print_m_hello_str:
+msg_m_hello:
         .string "Hello from M-mode!\n"
-print_u_hello_str:
-        .string "Hello from U-mode!\n"
-print_exception_str:
-        .string "Exception occured, mcause:%p mepc:%p mtval:%p (U-mode code starts at:%p).\n"
+msg_exception:
+        .string "Exception occured, mcause:%p mepc:%p mtval:%p (user payload at:%p, stack top:%p).\n"
 
 .section .data
 

--- a/baremetal-user.s
+++ b/baremetal-user.s
@@ -152,7 +152,7 @@ single_core:                            # only the 1st hart past this point
         .equ MODE_U,    (0b00 << 11)
         .equ MODE_S,    (0b01 << 11)
         .equ MODE_M,    (0b11 << 11)
-        .equ MODE_MASK, (0b11 << 11)
+        .equ MODE_MASK, ~(0b11 << 11)
 
                                         # use MRET instruction to switch privelege level from Machine (M-mode) to User (U-mode)
                                         # MRET will change privelege to Machine Previous Privelege stored in mstatus CSR

--- a/baremetal-user.s
+++ b/baremetal-user.s
@@ -18,7 +18,6 @@ _start:
         la      t0, early_trap_vector
         csrw    mtvec, t0
 
-        csrwi   mstatus, 0              # reset machine mode status
         csrwi   mideleg, 0              # disable trap delegation, all interrupts and exceptions will be handled in machine mode
         csrwi   medeleg, 0              # 3.1.13 Machine Trap Delegation Registers (medeleg and mideleg)
                                         # > In systems with all three privilege modes (M/S/U), setting a bit in medeleg or mideleg

--- a/baremetal.ld
+++ b/baremetal.ld
@@ -17,6 +17,7 @@ SECTIONS
   .data : { *(.data) }
   .sdata : { *(.sdata) }
   .debug : { *(.debug) }
+  stack_bottom = .;
   . += STACK_SIZE;
   stack_top = .;
 


### PR DESCRIPTION
* Setup Physical Memory Protection
* Align code and stack on 4KiB pages - it seems that QEMU tests access flags only once per page
* Use of constants to add clarity to code


qemu-system-riscv64 -nographic -machine sifive_u -bios none -kernel baremetal/user_sifive_u
Hello from M-mode!
Hello from U-mode!
Read user CSR: OK
Read from memory: OK
Read/write stack: OK
Read from unaligned memory:  OK
Illegal write to read-only memory: OK
Illegal read from protected CSR: Exception occured, mcause:0x2 mepc:0x80001114 mtval:0x0 (user payload at:0x80001000, stack top:0x80005000).
Illegal read from protected memory: Exception occured, mcause:0x5 mepc:0x80001130 mtval:0x80003000 (user payload at:0x80001000, stack top:0x80005000).
Done.
