### PR TITLE
Beginnings of a basic scheduler

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ runl: run-linux
 TEST_DEPS = src/baremetal-fib.s src/baremetal-print.s src/baremetal-poweroff.s
 HELLO_DEPS = src/baremetal-hello.s src/baremetal-print.s
 USER_DEPS = src/baremetal-user.s src/baremetal-print.s \
-			src/baremetal-poweroff.s src/userland.c
+			src/baremetal-poweroff.s src/userland.c src/kernel.c
 TEST_SIFIVE_U_DEPS = $(TEST_DEPS)
 HELLO_SIFIVE_U_DEPS = $(HELLO_DEPS)
 USER_SIFIVE_U_DEPS = $(USER_DEPS)

--- a/src/baremetal-hello.s
+++ b/src/baremetal-hello.s
@@ -184,8 +184,8 @@ set_timer_for_current_hart:             # Set the timer: read current time from 
 
 .ifdef RISCV64
         ld      t0, 0(t5)               # read from mtime memory-mapped register
-        add     t0, t0, a0              # t2 = mtime + 5sec
-        sd      t0, 0(t6)               # write t2 to mtimecmp
+        add     t0, t0, a0              # t0 = mtime + a0
+        sd      t0, 0(t6)               # write t0 to mtimecmp
 .else
         lw      t0, 0(t5)               # read from mtime memory-mapped into t0:t1 pair
         lw      t1, 4(t5)
@@ -193,13 +193,13 @@ set_timer_for_current_hart:             # Set the timer: read current time from 
 
                                         # add and write t1:t0 + t2 => t1:t4 into mtimecmp
 
-                                        # unsigned int overlow detection based on example from RISC-V ISA section Integer Computational Instructions:
+                                        # unsigned int overflow detection based on example from RISC-V ISA section Integer Computational Instructions:
                                         #     add t0, t1, t2; bltu t0, t1, overflow.
         add     t4, t0, t2
         bgeu    t4, t0, 1f              # bgeu == !bltu
         addi    t1, t1, 1               # handle overflow
 1:
-                                        # mtimecmp write in RV32 based on example from RISC-V Priveleged ISA section Machine Timer Registers:
+                                        # mtimecmp write in RV32 based on example from RISC-V Privileged ISA section Machine Timer Registers:
                                         #     li t0, -1; sw t0, mtimecmp; sw a1, mtimecmp+4; sw a0, mtimecmp.
         li      t0, -1
         sw      t0, 0(t6)               # 1) write unsigned (-1) into low 32bits of mtimecmp = no smaller than old value

--- a/src/baremetal-user.s
+++ b/src/baremetal-user.s
@@ -190,7 +190,7 @@ trap_vector:                            # 3.1.20 Machine Cause Register (mcause)
         j interrupt_timer               #  4: user timer interrupt
         j interrupt_timer               #  5: supervisor timer interrupt
         j interrupt_noop                #  6: reserved
-        j interrupt_timer               #  7: machine timer interrupt
+        j k_interrupt_timer             #  7: machine timer interrupt
         j interrupt_noop                #  8: user external interrupt
         j interrupt_noop                #  9: supervisor external interrupt
         j interrupt_noop                # 10: reserved
@@ -325,6 +325,9 @@ interrupt_noop:
 
 interrupt_timer:
         j       interrupt_epilogue
+
+k_interrupt_timer:
+        call    kernel_timer_tick
 
 syscall0:
         jal     poweroff

--- a/src/baremetal-user.s
+++ b/src/baremetal-user.s
@@ -368,8 +368,7 @@ user_entry_point:
                                         # which makes instruction address easier to follow in case of an exception
 
         call u_main
-
-        macro_sys_poweroff 0            # shutdown and exit QEMU, if possible
+        ret
 
 .globl sys_puts
 sys_puts:

--- a/src/baremetal-user.s
+++ b/src/baremetal-user.s
@@ -136,7 +136,11 @@ single_core:                            # only the 1st hart past this point
         la      a0, msg_m_hello         # DEBUG print
         call    printf                  # DEBUG print
 
-        call    kmain
+        call    kmain                   # kmain() will set up the kernel for further operations and return
+
+1:      wfi                             # after kmain() is done, halt this hart until the timer gets called, all the remaining
+        j       1b                      # kernel ops will be orchestrated from the timer
+                                        # parked hart will sleep waiting for interrupt
 
 
 ### Trap Tables & Dispatchers #################################################
@@ -328,6 +332,7 @@ interrupt_timer:
 
 k_interrupt_timer:
         call    kernel_timer_tick
+        j       interrupt_epilogue
 
 syscall0:
         jal     poweroff

--- a/src/baremetal-user.s
+++ b/src/baremetal-user.s
@@ -339,6 +339,14 @@ syscall4:
 test_func:
         ret
 
+.globl kprints
+kprints:
+        addi    sp, sp, -8
+        sx      ra, 8, (sp)
+        call    printf
+        lx      ra, 8, (sp)
+        addi    sp, sp, 8
+        ret
 
 ### User payload = code + readonly data for U-mode ############################
 #

--- a/src/baremetal-user.s
+++ b/src/baremetal-user.s
@@ -136,9 +136,9 @@ single_core:                            # only the 1st hart past this point
         la      a0, msg_m_hello         # DEBUG print
         call    printf                  # DEBUG print
 
-        call    kmain                   # kmain() will set up the kernel for further operations and return
+        call    kinit                   # kinit() will set up the kernel for further operations and return
 
-1:      wfi                             # after kmain() is done, halt this hart until the timer gets called, all the remaining
+1:      wfi                             # after kinit() is done, halt this hart until the timer gets called, all the remaining
         j       1b                      # kernel ops will be orchestrated from the timer
                                         # parked hart will sleep waiting for interrupt
 

--- a/src/baremetal-user.s
+++ b/src/baremetal-user.s
@@ -381,6 +381,17 @@ user_entry_point:
         call u_main
         ret
 
+.globl user_entry_point2
+user_entry_point2:
+        nop                             # no-operation instructions here help to distinguish between
+        nop                             # illegal instruction -vs- page fault due to missing e(X)ecute access flag
+        nop                             #
+        nop                             # 4 nops instead of one, to align the code below on 0x10
+                                        # which makes instruction address easier to follow in case of an exception
+
+        call u_main2
+        ret
+
 .globl sys_puts
 sys_puts:
         addi    sp, sp, -8

--- a/src/kernel.c
+++ b/src/kernel.c
@@ -64,9 +64,9 @@ void schedule_user_process() {
 }
 
 void init_process_table() {
-    proc_table[0].pid = 1;
+    proc_table[0].pid = 0;
     proc_table[0].pc = user_entry_point;
-    proc_table[1].pid = 2;
+    proc_table[1].pid = 1;
     proc_table[1].pc = user_entry_point2;
     // init curr_proc to -1, it will get incremented to 0 on the first
     // scheduler run. This will also help to identify the very first call to

--- a/src/kernel.c
+++ b/src/kernel.c
@@ -55,12 +55,12 @@ void kernel_timer_tick() {
 // schedule_user_process() is only called from kernel_timer_tick(), and MRET is
 // called in interrupt_epilogue, after kernel_timer_tick() exits.
 void schedule_user_process() {
-    set_user_mode();
     curr_proc++;
     if (curr_proc > 1) {
         curr_proc = 0;
     }
     jump_to_address(proc_table[curr_proc].pc);
+    set_user_mode();
 }
 
 void init_process_table() {

--- a/src/kernel.c
+++ b/src/kernel.c
@@ -9,8 +9,8 @@ typedef struct process_s {
 process_t proc_table[2];
 int curr_proc = 0;
 
-void kmain() {
-    kprints("kmain\n");
+void kinit() {
+    kprints("kinit\n");
     void *p = (void*)0xf10a;
     kprintp(p);
     init_process_table();

--- a/src/kernel.c
+++ b/src/kernel.c
@@ -25,7 +25,7 @@ void kernel_timer_tick() {
     disable_interrupts();
     kprints("K");
     void* userland_pc = (void*)get_mepc();
-    if (userland_pc) {
+    if (userland_pc && curr_proc >= 0) {
         proc_table[curr_proc].pc = userland_pc;
     }
     set_timer_after(ONE_SECOND);
@@ -69,7 +69,10 @@ void init_process_table() {
     proc_table[1].pid = 2;
     proc_table[1].pc = user_entry_point2;
     // init curr_proc to -1, it will get incremented to 0 on the first
-    // scheduler run:
+    // scheduler run. This will also help to identify the very first call to
+    // kernel_timer_tick, which will happen from the kernel land. We want to
+    // know that so we can discard the kernel code pc that we get on that first
+    // call.
     curr_proc = -1;
 }
 

--- a/src/kernel.c
+++ b/src/kernel.c
@@ -1,6 +1,9 @@
 #include "kernel.h"
 
 void kmain() {
+    kprints("kmain\n");
+    void *p = (void*)0xf10a;
+    kprintp(p);
     schedule_user_process();
 }
 
@@ -61,4 +64,20 @@ void jump_to_func(void *func) {
         :               // no output
         : "r"(func)     // input in func
     );
+}
+
+void kprintp(void* p) {
+    static char hex_table[] = "0123456789abcdef";
+    char buf[256];
+    int i = 15;
+    unsigned long pp = (unsigned long)p;
+    while (i >= 0) {
+        char lowest_4_bits = pp & 0xf;
+        buf[i] = hex_table[lowest_4_bits];
+        i--;
+        pp >>= 4;
+    }
+    buf[16] = '\n';
+    buf[17] = 0;
+    kprints(buf);
 }

--- a/src/kernel.c
+++ b/src/kernel.c
@@ -59,7 +59,7 @@ void schedule_user_process() {
     if (curr_proc > 1) {
         curr_proc = 0;
     }
-    jump_to_address(proc_table[curr_proc].pc);
+    set_jump_address(proc_table[curr_proc].pc);
     set_user_mode();
 }
 
@@ -111,7 +111,7 @@ void* get_mepc() {
     return a0;
 }
 
-void jump_to_address(void *func) {
+void set_jump_address(void *func) {
     asm volatile (
         "csrw   mepc, %0;"   // set mepc to userland function
         :            // no output

--- a/src/kernel.c
+++ b/src/kernel.c
@@ -29,8 +29,8 @@ void kernel_timer_tick() {
         proc_table[curr_proc].pc = userland_pc;
     }
     set_timer_after(ONE_SECOND);
-    enable_interrupts();
     schedule_user_process();
+    enable_interrupts();
 }
 
 // 3.1.7 Privilege and Global Interrupt-Enable Stack in mstatus register

--- a/src/kernel.c
+++ b/src/kernel.c
@@ -1,0 +1,64 @@
+#include "kernel.h"
+
+void kmain() {
+    schedule_user_process();
+}
+
+void schedule_user_process() {
+    set_user_mode();
+    jump_to_func(user_entry_point);
+}
+
+// Privilege levels are encoded in 2 bits: User = 0b00, Supervisor = 0b01,
+// Machine = 0b11 and stored in 11:12 bits of mstatus CSR (called mstatus.mpp)
+void set_user_mode() {
+    unsigned int mstatus = get_mstatus();
+    mstatus &= MODE_MASK;   // zero out mode bits 11:12
+    mstatus |= MODE_U;      // set them to user mode
+    set_mstatus(mstatus);
+}
+
+unsigned int get_mstatus() {
+    register unsigned int a0 asm ("a0");
+    asm volatile (
+        "csrr a0, mstatus"
+        : "=r"(a0)      // output in a0
+    );
+    return a0;
+}
+
+void set_mstatus(unsigned int mstatus) {
+    register unsigned int a0 asm ("a0");
+    asm volatile (
+        "csrw mstatus, a0"
+        :               // no output
+        : "r"(a0)       // input in a0
+    );
+}
+
+// 3.1.7 Privilege and Global Interrupt-Enable Stack in mstatus register
+// > The MRET, SRET, or URET instructions are used to return from traps in
+// > M-mode, S-mode, or U-mode respectively. When executing an xRET instruction,
+// > supposing x PP holds the value y, x IE is set to xPIE; the privilege mode
+// > is changed to > y; xPIE is set to 1; and xPP is set to U (or M if user-mode
+// > is not supported).
+//
+// 3.2.2 Trap-Return Instructions
+// > An xRET instruction can be executed in privilege mode x or higher,
+// > where executing a lower-privilege xRET instruction will pop
+// > the relevant lower-privilege interrupt enable and privilege mode stack.
+// > In addition to manipulating the privilege stack as described in Section
+// > 3.1.7, xRET sets the pc to the value stored in the x epc register.
+//
+// Use MRET instruction to switch privilege level from Machine (M-mode) to User
+// (U-mode) MRET will change privilege to Machine Previous Privilege stored in
+// mstatus CSR and jump to Machine Exception Program Counter specified by mepc
+// CSR.
+void jump_to_func(void *func) {
+    asm volatile (
+        "csrw   mepc, %0;"   // set mepc to userland function
+        "mret;"              // mret will jump to what mepc points to
+        :               // no output
+        : "r"(func)     // input in func
+    );
+}

--- a/src/kernel.h
+++ b/src/kernel.h
@@ -7,11 +7,29 @@
 #define MODE_M      3 << 11
 #define MODE_MASK ~(3 << 11)
 
+// These addresses are taken from the SiFive E31 core manual[1],
+// Chapter 8: Core Local Interruptor (CLINT)
+// [1] https://static.dev.sifive.com/E31-RISCVCoreIP.pdf
+#define MTIME             0x200bff8
+#define MTIMECMP_BASE     0x2004000
+
+// Based on SIFIVE_CLINT_TIMEBASE_FREQ = 10000000 value from QEMU SiFive CLINT
+// implementation:
+// https://github.com/qemu/qemu/blob/master/include/hw/intc/sifive_clint.h
+#define ONE_SECOND        10*1000*1000
+
 void schedule_user_process();
 void set_user_mode();
 void jump_to_func(void *func);
 unsigned int get_mstatus();
 void set_mstatus(unsigned int mstatus);
+void* get_mepc();
+void kernel_timer_tick();
+void set_timer();
+void disable_interrupts();
+void enable_interrupts();
+void set_mie(unsigned int value);
+void set_timer_after(uint64_t delta);
 void kprints(char const *msg);
 void kprintp(void* p);
 

--- a/src/kernel.h
+++ b/src/kernel.h
@@ -1,0 +1,18 @@
+#ifndef _KERNEL_H_
+#define _KERNEL_H_
+
+// 1.3 Privilege Levels, Table 1.1: RISC-V privilege levels.
+#define MODE_U      0 << 11
+#define MODE_S      1 << 11
+#define MODE_M      3 << 11
+#define MODE_MASK ~(3 << 11)
+
+void schedule_user_process();
+void set_user_mode();
+void jump_to_func(void *func);
+unsigned int get_mstatus();
+void set_mstatus(unsigned int mstatus);
+
+extern void user_entry_point();
+
+#endif // ifndef _KERNEL_H_

--- a/src/kernel.h
+++ b/src/kernel.h
@@ -18,6 +18,7 @@
 // https://github.com/qemu/qemu/blob/master/include/hw/intc/sifive_clint.h
 #define ONE_SECOND        10*1000*1000
 
+void init_process_table();
 void schedule_user_process();
 void set_user_mode();
 void jump_to_address(void *func);

--- a/src/kernel.h
+++ b/src/kernel.h
@@ -21,7 +21,7 @@
 void init_process_table();
 void schedule_user_process();
 void set_user_mode();
-void jump_to_address(void *func);
+void set_jump_address(void *func);
 unsigned int get_mstatus();
 void set_mstatus(unsigned int mstatus);
 void* get_mepc();

--- a/src/kernel.h
+++ b/src/kernel.h
@@ -12,6 +12,8 @@ void set_user_mode();
 void jump_to_func(void *func);
 unsigned int get_mstatus();
 void set_mstatus(unsigned int mstatus);
+void kprints(char const *msg);
+void kprintp(void* p);
 
 extern void user_entry_point();
 

--- a/src/kernel.h
+++ b/src/kernel.h
@@ -34,5 +34,6 @@ void kprints(char const *msg);
 void kprintp(void* p);
 
 extern void user_entry_point();
+extern void user_entry_point2();
 
 #endif // ifndef _KERNEL_H_

--- a/src/kernel.h
+++ b/src/kernel.h
@@ -20,7 +20,7 @@
 
 void schedule_user_process();
 void set_user_mode();
-void jump_to_func(void *func);
+void jump_to_address(void *func);
 unsigned int get_mstatus();
 void set_mstatus(unsigned int mstatus);
 void* get_mepc();

--- a/src/userland.c
+++ b/src/userland.c
@@ -38,6 +38,20 @@ int _userland u_main() {
     // causes Load access fault (mcause=5) in User mode:
     word = *msg_m_hello_ptr;
 
+    int64_t counter = 0;
+    int flipper = 0;
+    while (1) {
+        counter++;
+        if (counter % 10000000 == 0) {
+            flipper++;
+            if ((flipper & 1) == 0) {
+                sys_puts("-");
+            } else {
+                sys_puts("|");
+            }
+        }
+    }
+
     sys_puts("C Done.\n");
     return 0;
 }

--- a/src/userland.c
+++ b/src/userland.c
@@ -56,6 +56,58 @@ int _userland u_main() {
     return 0;
 }
 
+int _userland u_main2() {
+    sys_puts("Hello from U-mode 2!\n");
+
+    sys_puts("Read user CSR: ");
+    uint64_t clock_cycles = get_clock_cycles();
+    sys_puts("OK\n");
+
+    sys_puts("Read from memory: ");
+    int word = *a_string_in_user_mem_ptr;
+    sys_puts("OK\n");
+
+    sys_puts("Read from unaligned memory: ");
+    char *cptr = (char*)a_string_in_user_mem_ptr;
+    cptr++;
+    char c = *cptr;
+    sys_puts("OK\n");
+
+    sys_puts("Read/write stack: ");
+    push_pop_stack();
+    sys_puts("OK\n");
+
+    sys_puts("Illegal write to read-only memory: ");
+    // XXX: this ought to fail, but succeeds in QEMU for some reason:
+    *a_string_in_user_mem_ptr = 7;
+    sys_puts("OK\n");
+
+    sys_puts("Illegal read from protected CSR: ");
+    // causes Illegal instruction (mcause=2) in User mode:
+    int hart_id = m_read_hart_id();
+
+    sys_puts("Illegal read from protected memory: ");
+    // causes Load access fault (mcause=5) in User mode:
+    word = *msg_m_hello_ptr;
+
+    int64_t counter = 0;
+    int flipper = 0;
+    while (1) {
+        counter++;
+        if (counter % 10000000 == 0) {
+            flipper++;
+            if ((flipper & 1) == 0) {
+                sys_puts(".");
+            } else {
+                sys_puts("o");
+            }
+        }
+    }
+
+    sys_puts("C Done.\n");
+    return 0;
+}
+
 uint64_t _userland get_clock_cycles() {
     register uint64_t a0 asm ("a0");
 #if XLEN == 64


### PR DESCRIPTION
Started moving kernel code to C. Added kernel-mode timer interrupt, which captures userland program counter, schedules itself for the next tick and returns to the user process at the point where it was interrupted.