### PR TITLE
Cleanup: move kernel scheduler tick time to a separate constant

### DIFF
--- a/include/kernel.h
+++ b/include/kernel.h
@@ -18,6 +18,8 @@
 // https://github.com/qemu/qemu/blob/master/include/hw/intc/sifive_clint.h
 #define ONE_SECOND        10*1000*1000
 
+#define KERNEL_SCHEDULER_TICK_TIME (ONE_SECOND)
+
 void init_process_table();
 void schedule_user_process();
 void set_user_mode();

--- a/src/kernel.c
+++ b/src/kernel.c
@@ -14,7 +14,7 @@ void kinit() {
     void *p = (void*)0xf10a; // this is a random hex to test out kprintp()
     kprintp(p);
     init_process_table();
-    set_timer_after(ONE_SECOND);
+    set_timer_after(KERNEL_SCHEDULER_TICK_TIME);
     enable_interrupts();
 }
 
@@ -28,7 +28,7 @@ void kernel_timer_tick() {
     if (userland_pc && curr_proc >= 0) {
         proc_table[curr_proc].pc = userland_pc;
     }
-    set_timer_after(ONE_SECOND);
+    set_timer_after(KERNEL_SCHEDULER_TICK_TIME);
     schedule_user_process();
     enable_interrupts();
 }


### PR DESCRIPTION
It feels more natural to adjust tick time in terms of one second that to
change a definition of a second.