### PR TITLE
Fix warning in kprintp

### DIFF
--- a/src/boot.s
+++ b/src/boot.s
@@ -330,11 +330,11 @@ k_interrupt_timer:
 
 .globl kprints
 kprints:
-        addi    sp, sp, -8
-        sx      ra, 8, (sp)
+        stackalloc_x 1
+        sx      ra, 1, (sp)
         call    printf
-        lx      ra, 8, (sp)
-        addi    sp, sp, 8
+        lx      ra, 1, (sp)
+        stackfree_x 1
         ret
 
 ### User payload = code + readonly data for U-mode ############################
@@ -380,11 +380,11 @@ user_entry_point2:
 
 .globl sys_puts
 sys_puts:
-        addi    sp, sp, -8
-        sx      ra, 8, (sp)
+        stackalloc_x 1
+        sx      ra, 1, (sp)
         macro_syscall 4
-        lx      ra, 8, (sp)
-        addi    sp, sp, 8
+        lx      ra, 1, (sp)
+        stackfree_x 1
         ret
 
 a_string_in_user_mem:

--- a/src/kernel.c
+++ b/src/kernel.c
@@ -160,16 +160,18 @@ void enable_interrupts() {
 
 void kprintp(void* p) {
     static char hex_table[] = "0123456789abcdef";
-    char buf[256];
-    int i = 15;
-    uint64_t pp = (uint64_t)p;
+    static char buf[64];
+    int i = sizeof(p)*2 + 1;
+    buf[i] = '\0';
+    i--;
+    buf[i] = '\n';
+    i--;
+    unsigned long pp = (unsigned long)p;
     while (i >= 0) {
         char lowest_4_bits = pp & 0xf;
         buf[i] = hex_table[lowest_4_bits];
         i--;
         pp >>= 4;
     }
-    buf[16] = '\n';
-    buf[17] = 0;
     kprints(buf);
 }


### PR DESCRIPTION
Unhardcode the expected fixed size of pointer, make it dependent on the
actual sizeof(p).

Also, fix a bug with stack handling in kprints and sys_puts. I was
misusing the sx/lx macros by specifying an offset in bytes to them instead
of an offset in registers. Use stackalloc_x/stackfree_x along with sx/lx
to symmetrically specify number of registers to both.