### PR TITLE
Move memory protection init code to C

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,8 @@ runl: run-linux
 
 TEST_DEPS = src/baremetal-fib.s src/baremetal-print.s src/baremetal-poweroff.s
 USER_DEPS = src/boot.s src/baremetal-print.s \
-			src/baremetal-poweroff.s src/userland.c src/kernel.c src/syscalls.c
+			src/baremetal-poweroff.s src/userland.c src/kernel.c src/syscalls.c \
+			src/pmp.c src/riscv.c
 TEST_SIFIVE_U_DEPS = $(TEST_DEPS)
 USER_SIFIVE_U_DEPS = $(USER_DEPS)
 TEST_SIFIVE_E_DEPS = $(TEST_DEPS)

--- a/include/kernel.h
+++ b/include/kernel.h
@@ -1,17 +1,8 @@
 #ifndef _KERNEL_H_
 #define _KERNEL_H_
 
-// 1.3 Privilege Levels, Table 1.1: RISC-V privilege levels.
-#define MODE_U      0 << 11
-#define MODE_S      1 << 11
-#define MODE_M      3 << 11
-#define MODE_MASK ~(3 << 11)
-
-// These addresses are taken from the SiFive E31 core manual[1],
-// Chapter 8: Core Local Interruptor (CLINT)
-// [1] https://static.dev.sifive.com/E31-RISCVCoreIP.pdf
-#define MTIME             0x200bff8
-#define MTIMECMP_BASE     0x2004000
+#include "riscv.h"
+#include "pmp.h"
 
 // Based on SIFIVE_CLINT_TIMEBASE_FREQ = 10000000 value from QEMU SiFive CLINT
 // implementation:
@@ -20,23 +11,15 @@
 
 #define KERNEL_SCHEDULER_TICK_TIME (ONE_SECOND)
 
-#define TRAP_DIRECT   0x00
-#define TRAP_VECTORED 0x01
-
 void init_process_table();
 void init_trap_vector();
 void schedule_user_process();
 void set_user_mode();
 void set_jump_address(void *func);
-unsigned int get_mstatus();
-void set_mstatus(unsigned int mstatus);
-void* get_mepc();
 void kernel_timer_tick();
 void set_timer();
 void disable_interrupts();
 void enable_interrupts();
-void set_mie(unsigned int value);
-void set_mtvec(void *ptr);
 void set_timer_after(uint64_t delta);
 void kprints(char const *msg);
 void kprintp(void* p);

--- a/include/pmp.h
+++ b/include/pmp.h
@@ -1,0 +1,27 @@
+#ifndef _PMP_H
+#define _PMP_H
+
+#define PMP_LOCK  (1 << 7)
+#define PMP_NAPOT (3 << 3)          // Address Mode: Naturally aligned power-of-two region, >=8 bytes
+#define PMP_NA4   (2 << 3)          // Address Mode: Naturally aligned four-byte region
+#define PMP_TOR   (1 << 3)          // Address Mode: Top of range, address register forms the top of the address range,
+
+#define PMP_X     (1 << 2)          // Access Mode: Executable
+#define PMP_W     (1 << 1)          // Access Mode: Writable
+#define PMP_R     (1 << 0)          // Access Mode: Readable
+#define PMP_0     (1 << 0)          // [0..8]   1st PMP entry in pmpcfgX register
+#define PMP_1     (1 << 8)          // [8..16]  2nd PMP entry in pmpcfgX register
+#define PMP_2     (1 << 16)         // [16..24] 3rd PMP entry in pmpcfgX register
+#define PMP_3     (1 << 24)         // [24..32] 4th PMP entry in pmpcfgX register
+
+// defined in boot.s:
+extern void* user_payload;
+extern void* rodata;
+
+// defined in baremetal.ld:
+extern void* stack_bottom;
+extern void* stack_top;
+
+void init_pmp();
+
+#endif // ifndef _PMP_H

--- a/include/riscv.h
+++ b/include/riscv.h
@@ -1,0 +1,33 @@
+#ifndef _RISCV_H_
+#define _RISCV_H_
+
+#include "sys.h"
+
+// 1.3 Privilege Levels, Table 1.1: RISC-V privilege levels.
+#define MODE_U      0 << 11
+#define MODE_S      1 << 11
+#define MODE_M      3 << 11
+#define MODE_MASK ~(3 << 11)
+
+// These addresses are taken from the SiFive E31 core manual[1],
+// Chapter 8: Core Local Interruptor (CLINT)
+// [1] https://static.dev.sifive.com/E31-RISCVCoreIP.pdf
+#define MTIME             0x200bff8
+#define MTIMECMP_BASE     0x2004000
+
+#define TRAP_DIRECT   0x00
+#define TRAP_VECTORED 0x01
+
+unsigned int get_mstatus();
+void set_mstatus(unsigned int mstatus);
+void* get_mepc();
+void set_mie(unsigned int value);
+void set_mtvec(void *ptr);
+
+void set_pmpaddr0(void* addr);
+void set_pmpaddr1(void* addr);
+void set_pmpaddr2(void* addr);
+void set_pmpaddr3(void* addr);
+void set_pmpcfg0(unsigned long value);
+
+#endif // ifndef _RISCV_H_

--- a/src/kernel.c
+++ b/src/kernel.c
@@ -12,6 +12,7 @@ int curr_proc = 0;
 void kinit() {
     kprints("kinit\n");
     init_trap_vector();
+    init_pmp();
     void *p = (void*)0xf10a; // this is a random hex to test out kprintp()
     kprintp(p);
     init_process_table();
@@ -19,6 +20,16 @@ void kinit() {
     enable_interrupts();
 }
 
+// 3.1.12 Machine Trap-Vector Base-Address Register (mtvec)
+// > When MODE=Vectored, all synchronous exceptions into machine mode cause
+// > the pc to be set to the address in the BASE field, whereas interrupts
+// > cause the pc to be set to the address in the BASE field plus four times
+// > the interrupt cause number. When vectored interrupts are enabled,
+// > interrupt cause 0, which corresponds to user-mode software interrupts, are
+// > vectored to the same location as synchronous > exceptions. This ambiguity
+// > does not arise in practice, since user-mode software interrupts are either
+// > disabled or delegated to a less-privileged mode.
+//
 // init_trap_vector initializes the exception, interrupt & syscall trap vector
 // in the mtvec register.
 //

--- a/src/pmp.c
+++ b/src/pmp.c
@@ -1,0 +1,47 @@
+#include "kernel.h"
+
+// 3.6.1 Physical Memory Protection CSRs
+// > PMP entries are described by an 8-bit configuration register AND one XLEN-bit address register.
+// > The PMP configuration registers are densely packed into CSRs to minimize context-switch time.
+// >
+// > For RV32, pmpcfg0..pmpcfg3, hold the configurations pmp0cfg..pmp15cfg for the 16 PMP entries.
+// > For RV64, pmpcfg0 and pmpcfg2 hold the configurations for the 16 PMP entries; pmpcfg1 and pmpcfg3 are illegal.
+// > For RV32, each PMP address register encodes bits 33:2 of a 34-bit physical address.
+// > For RV64, each PMP address register encodes bits 55:2 of a 56-bit physical address.
+// >
+// > The R, W, and X bits, when set, indicate that the PMP entry permits read, write, and instruction execution.
+// >
+// > If PMP entry i's A field is set to TOR, the associated address register forms the top of the address range,
+// > the entry matches any address a such that pmpaddr[i-1] <= a < pmpaddr[i]. If PMP entry 0's A field
+// > is set to TOR, zero is used for the lower bound, and so it matches any address a < pmpaddr0.
+// >
+// > PMP entries are statically prioritized. The lowest-numbered PMP entry that matches any byte
+// > of an access determines whether that access succeeds or fails.
+
+void init_pmp() {
+    // define 4 memory address ranges for Physical Memory Protection
+    // 0 :: [0 .. user_payload]
+    // 1 :: [user_payload .. .rodata]
+    // 2 :: [.rodata .. stack_bottom]
+    // 3 :: [stack_bottom .. stack_top]
+    set_pmpaddr0(&user_payload);
+    set_pmpaddr1(&rodata);
+    set_pmpaddr2(&stack_bottom);
+    set_pmpaddr3(&stack_top);
+
+    // set 4 PMP entries to TOR (Top Of the address Range) addressing mode so that the associated
+    // address register forms the top of the address range per entry,
+    // the type of PMP entry is encoded in 2 bits: OFF = 0, TOR = 1, NA4 = 2, NAPOT = 3
+    // and stored in 3:4 bits of every PMP entry
+    unsigned long mode = PMP_TOR * (PMP_0 | PMP_1 | PMP_2 | PMP_3);
+
+    // set access flags for 4 PMP entries:
+    // 0 :: [0 .. user_payload]                      000  M-mode kernel code, no access in U-mode
+    // 1 :: [user_payload .. .rodata]                X0R  user code, executable, non-modifiable in U-mode
+    // 2 :: [.rodata .. stack_bottom]                000  no access in U-mode
+    // 3 :: [stack_bottom .. stack_top]              0WR  user stack, modifiable, but no executable in U-mode
+    // access (R)ead, (W)rite and e(X)ecute are 1 bit flags and stored in 0:2 bits of every PMP entry
+    unsigned long access_flags =   ((PMP_X | PMP_R) * PMP_1)
+                                 | ((PMP_W | PMP_R) * PMP_3);
+    set_pmpcfg0(mode | access_flags);
+}

--- a/src/riscv.c
+++ b/src/riscv.c
@@ -1,0 +1,50 @@
+#include "kernel.h"
+
+void* shift_right_addr(void* addr, int bits) {
+    unsigned long iaddr = (unsigned long)addr;
+    return (void*)(iaddr >> bits);
+}
+
+void set_pmpaddr0(void* addr) {
+    addr = shift_right_addr(addr, 2);
+    asm volatile (
+        "csrw   pmpaddr0, %0;"  // set pmpaddr0 to the requested addr
+        :                       // no output
+        : "r"(addr)             // input in addr
+    );
+}
+
+void set_pmpaddr1(void* addr) {
+    addr = shift_right_addr(addr, 2);
+    asm volatile (
+        "csrw   pmpaddr1, %0;"  // set pmpaddr1 to the requested addr
+        :                       // no output
+        : "r"(addr)             // input in addr
+    );
+}
+
+void set_pmpaddr2(void* addr) {
+    addr = shift_right_addr(addr, 2);
+    asm volatile (
+        "csrw   pmpaddr2, %0;"  // set pmpaddr2 to the requested addr
+        :                       // no output
+        : "r"(addr)             // input in addr
+    );
+}
+
+void set_pmpaddr3(void* addr) {
+    addr = shift_right_addr(addr, 2);
+    asm volatile (
+        "csrw   pmpaddr3, %0;"  // set pmpaddr3 to the requested addr
+        :                       // no output
+        : "r"(addr)             // input in addr
+    );
+}
+
+void set_pmpcfg0(unsigned long value) {
+    asm volatile (
+        "csrw   pmpcfg0, %0;"   // set pmpcfg0 to the requested value
+        :                       // no output
+        : "r"(value)            // input in value
+    );
+}


### PR DESCRIPTION
Also started moving low level RISC-V-specific functions and constants to
separate files. Later higher-level wrappers will emerge above them in
order to make C code less assembly-like and more readable.