### PR TITLE
Streamline running gdb

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ initramfs
 initramfs-busybox-riscv64.cpio.gz
 generic-elf
 out
+/sifive-freedom-toolchain
+/.debug-session
+/.gdbinit

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,18 @@ ifeq ($(wildcard $(RISCV_PK)),)
 	RISCV_PK = pk
 endif
 
+FREEDOM_SDK_TOOLCHAIN_PATH := ./sifive-freedom-toolchain/$(shell ls sifive-freedom-toolchain)
+
+# If the links below get outdated, head to https://www.sifive.com/software and
+# download GNU Embedded Toolchain.
+UNAME := $(shell uname)
+ifeq ($(UNAME), Linux)
+	SIFIVE_TOOLCHAIN_URL := https://static.dev.sifive.com/dev-tools/freedom-tools/v2020.12/riscv64-unknown-elf-toolchain-10.2.0-2020.12.8-x86_64-linux-ubuntu14.tar.gz
+endif
+ifeq ($(UNAME), Darwin)
+	SIFIVE_TOOLCHAIN_URL := https://static.dev.sifive.com/dev-tools/freedom-tools/v2020.12/riscv64-unknown-elf-toolchain-10.2.0-2020.12.8-x86_64-apple-darwin.tar.gz
+endif
+
 OUT := out
 BINS := $(OUT)/test_sifive_u \
 	$(OUT)/user_sifive_u \
@@ -77,6 +89,19 @@ run-baremetal: $(OUT)/user_sifive_u
 .PHONY: run-baremetal32
 run-baremetal32: $(OUT)/user_sifive_e32
 	$(QEMU_LAUNCHER) --binary=$<
+
+# Note:
+# * if this target complains that it can't find riscv64-unknown-elf-gdb,
+#   run make download-sifive-toolchain
+# * .debug-session file is not there permanently; it's being created by
+#   qemu-launcher for the duration of the session and is being cleaned up on
+#   exit. The file contains the name of the binary to debug
+# * qemu-launcher also creates a .gbdinit file so that gdb sets the correct
+#   arch and automatically attaches to the target
+.PHONY: gdb
+gdb:
+	$(FREEDOM_SDK_TOOLCHAIN_PATH)/bin/riscv64-unknown-elf-gdb \
+		$(shell cat .debug-session)
 
 GCC_FLAGS=-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles \
           -Tsrc/baremetal.ld -Iinclude
@@ -153,7 +178,7 @@ clean:
 	rm -Rf $(OUT)
 
 prereqs:
-	# OSX brew install gawk gnu-sed gmp mpfr libmpc isl zlib expat
+	# OSX brew install gawk gnu-sed gmp mpfr libmpc isl zlib expat wget
 	# OSX brew install riscv-tools qemu
 	sudo apt --yes install \
 		autoconf \
@@ -178,7 +203,13 @@ prereqs:
 		patchutils \
 		pkg-config \
 		texinfo gperf \
+		wget \
 		zlib1g-dev
+
+.PHONY: download-sifive-toolchain
+download-sifive-toolchain:
+	mkdir -p sifive-freedom-toolchain
+	wget -qO- "$(SIFIVE_TOOLCHAIN_URL)" | tar xzv -C "sifive-freedom-toolchain"
 
 clone:
 	git clone https://github.com/qemu/qemu

--- a/README.md
+++ b/README.md
@@ -22,11 +22,10 @@ Make targets
 Debugging with gdb
 ------------------
 
-1. You will need to download toolchain from SiFive. Download GNU Embedded
-   Toolchain from [here][sifive-toolchain] and extract it to `~/some/path/`.
-2. Run as usual with and extra `DBG=1` argument, e.g. `make run-baremetal-user DBG=1`
-3. In a separate terminal, run `~/some/path/bin/riscv64-unknown-elf-gdb`
-4. When in gdb, attach with `target remote localhost:1234`
+1. `make download-sifive-toolchain` to download SiFive version of toolchain, as
+   the regular apt-gettable toolchain won't work
+2. Run as usual with and extra `DBG=1` argument, e.g. `make run-baremetal DBG=1`
+3. In a separate terminal, run `make gdb`
 
 RISC-V Linux in QEMU
 ====================

--- a/scripts/qemu-launcher.py
+++ b/scripts/qemu-launcher.py
@@ -5,11 +5,16 @@
 from datetime import datetime, timedelta
 
 import argparse
+import contextlib
 import io
 import os
 import signal
 import subprocess
 import sys
+
+
+DEBUG_SESSION_FILE = '.debug-session'
+GDBINIT_FILE = '.gdbinit'
 
 
 def mkdelta(deltavalue):
@@ -50,6 +55,21 @@ def pipe_bytes(r, w):
         w.flush()
 
 
+def write_gdb_files(binary, is_32bit):
+    with open(DEBUG_SESSION_FILE, 'w') as f:
+        f.write(binary)
+    with open(GDBINIT_FILE, 'w') as f:
+        if is_32bit:
+            f.write('set arch riscv:rv32\n')
+        f.write('target remote localhost:1234\n')
+
+
+def cleanup_gdb_files():
+    with contextlib.suppress(FileNotFoundError):
+        os.unlink(DEBUG_SESSION_FILE)
+        os.unlink(GDBINIT_FILE)
+
+
 def make_qemu_command(args):
     binary = args.binary
 
@@ -80,7 +100,7 @@ def make_qemu_command(args):
             '-S',  # only loads an image, but stops the CPU, giving a chance to attach gdb
             '-s',  # a shorthand to listen for gdb on localhost:1234
         ])
-    return cmd
+    return cmd, binary, qemu.endswith('riscv32')
 
 
 def run(args):
@@ -102,9 +122,12 @@ def run(args):
     timeout = None
     if args.timeout is not None:
         timeout = mkdelta(args.timeout)
+    cmd, binary, is_32bit = make_qemu_command(args)
+    if args.debug:
+        write_gdb_files(binary, is_32bit)
     filename = 'out/test-run-{}.log'.format(os.path.basename(args.binary))
     with io.open(filename, 'wb') as writer, io.open(filename, 'rb', 1) as reader:
-        p = subprocess.Popen(make_qemu_command(args),
+        p = subprocess.Popen(cmd,
                              stdin=subprocess.PIPE,
                              stdout=writer, stderr=writer,
                              )
@@ -119,6 +142,7 @@ def run(args):
                     break
         # write the remainder:
         pipe_bytes(reader, sys.stdout)
+    cleanup_gdb_files()
 
 
 def main():


### PR DESCRIPTION
Running gdb is now super easy, just two commands:

    make run-baremetal DBG=1    # just like before
    make gdb                    # magic!

The magic is achieved by qemu-launcher, which knows enough to write a
.gdbinit file, which gdb picks up automatically, and when it does, it's
ready to start debugging right away.