### PR TITLE
Implement parameter passing to kernel on unleashed machines

### DIFF
--- a/.github/workflows/maketest.yml
+++ b/.github/workflows/maketest.yml
@@ -17,7 +17,11 @@ jobs:
       run: ./scripts/install-ci.sh
     - name: Print xcompiler version
       run: riscv64-linux-gnu-gcc --version
-    - name: Run tests
+    - name: Run virt tests
       run: make test
+    - name: Run u64 tests
+      run: make out/test-output-u64.txt
+    - name: Run u32 tests
+      run: make out/test-output-u32.txt
     - name: Make all binaries
       run: make all

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ runs: run-spike
 TEST_DEPS = src/baremetal-fib.s src/baremetal-print.s src/baremetal-poweroff.s
 USER_DEPS = src/boot.s src/baremetal-print.s \
 			src/baremetal-poweroff.s src/userland.c src/kernel.c src/syscalls.c \
-			src/pmp.c src/riscv.c
+			src/pmp.c src/riscv.c src/fdt.c src/string.c src/proc_test.c
 TEST_SIFIVE_U_DEPS = $(TEST_DEPS)
 USER_SIFIVE_U_DEPS = $(USER_DEPS)
 TEST_SIFIVE_E_DEPS = $(TEST_DEPS)
@@ -70,15 +70,34 @@ test: $(OUT)/test-output.txt
 $(OUT)/test-output.txt: $(OUT)/test_virt
 	@$(QEMU_LAUNCHER) --machine=virt --binary=$< > $@
 
+$(OUT)/test-output-u64.txt: $(OUT)/user_sifive_u
+	@$(QEMU_LAUNCHER) --bootargs dry-run --timeout=5s --binary=$< > $@
+	@diff -u testdata/want-output-u64.txt $@
+	@echo "OK"
+
+$(OUT)/test-output-u32.txt: $(OUT)/user_sifive_u32
+	@$(QEMU_LAUNCHER) --bootargs dry-run --timeout=5s --binary=$< > $@
+	@diff -u testdata/want-output-u32.txt $@
+	@echo "OK"
+
 .PHONY: run-baremetal
 run-baremetal: $(OUT)/user_sifive_u
+	$(QEMU_LAUNCHER) --binary=$<
+
+.PHONY: run-baremetale64
+run-baremetale64: $(OUT)/user_sifive_e
 	$(QEMU_LAUNCHER) --binary=$<
 
 .PHONY: run-baremetal32
 run-baremetal32: $(OUT)/user_sifive_e32
 	$(QEMU_LAUNCHER) --binary=$<
 
+.PHONY: run-baremetalu32
+run-baremetalu32: $(OUT)/user_sifive_u32
+	$(QEMU_LAUNCHER) --binary=$<
+
 GCC_FLAGS=-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles \
+          -ffreestanding \
           -Tsrc/baremetal.ld -Iinclude
 
 $(OUT)/test_sifive_u: ${TEST_SIFIVE_U_DEPS}

--- a/include/fdt.h
+++ b/include/fdt.h
@@ -1,0 +1,34 @@
+#ifndef _FDT_H_
+#define _FDT_H_
+
+#include "sys.h"
+
+// FDT header signature.
+#define FDT_MAGIC       0xd00dfeed
+
+// This is implemented against version 17 of the devicetree spec.
+#define FDT_VERSION     17
+
+#define FDT_BEGIN_NODE  0x00000001
+#define FDT_END_NODE    0x00000002
+#define FDT_PROP        0x00000003
+#define FDT_NOP         0x00000004
+#define FDT_END         0x00000009
+
+typedef struct fdt_header_s {
+    uint32_t magic;
+    uint32_t totalsize;
+    uint32_t off_dt_struct;
+    uint32_t off_dt_strings;
+    uint32_t off_mem_rsvmap;
+    uint32_t version;
+    uint32_t last_comp_version;
+    uint32_t boot_cpuid_phys;
+    uint32_t size_dr_strings;
+    uint32_t size_dt_struct;
+} fdt_header;
+
+void fdt_init(uintptr_t header_addr);
+char const* fdt_get_bootargs();
+
+#endif // ifndef _FDT_H_

--- a/include/kernel.h
+++ b/include/kernel.h
@@ -11,6 +11,7 @@
 
 #define KERNEL_SCHEDULER_TICK_TIME (ONE_SECOND)
 
+void kinit(uintptr_t fdt_header_addr);
 void init_process_table();
 void init_trap_vector();
 void schedule_user_process();

--- a/include/proc.h
+++ b/include/proc.h
@@ -1,0 +1,21 @@
+#ifndef _PROC_H_
+#define _PROC_H_
+
+// TODO: move other process-related stuff here
+
+#define MAX_PROCS 2
+
+typedef struct process_s {
+    int pid;
+    void *pc;
+} process_t;
+
+extern process_t proc_table[MAX_PROCS];
+extern int num_procs;
+
+// init_test_processes initializes the process table with a set of userland
+// processes that will get executed by default. Kind of like what an initrd
+// would do, but a poor man's version until we can do better.
+void init_test_processes();
+
+#endif // ifndef _PROC_H_

--- a/include/string.h
+++ b/include/string.h
@@ -1,0 +1,7 @@
+#ifndef _STRING_H_
+#define _STRING_H_
+
+int strncmp(char const *a, char const *b, unsigned int num);
+char* strncpy(char *dest, char const *src, unsigned int num);
+
+#endif // ifndef _STRING_H_

--- a/include/sys.h
+++ b/include/sys.h
@@ -7,13 +7,19 @@
     #define XLEN 32
     #define int64_t long long
     #define uint64_t unsigned long long
+    #define uint32_t unsigned long
+    #define uintptr_t unsigned long
 #elif __riscv_xlen == 64
     #define XLEN 64
     #define int64_t long
     #define uint64_t unsigned long
+    #define uint32_t unsigned int
+    #define uintptr_t unsigned long
 #else
     #error Unknown xlen
 #endif
+
+#define ARRAY_LENGTH(a) (sizeof(a) / sizeof(a[0]))
 
 extern void sys_puts(char const* msg);
 

--- a/scripts/qemu-launcher.py
+++ b/scripts/qemu-launcher.py
@@ -80,6 +80,8 @@ def make_qemu_command(args):
             '-S',  # only loads an image, but stops the CPU, giving a chance to attach gdb
             '-s',  # a shorthand to listen for gdb on localhost:1234
         ])
+    if args.bootargs:
+        cmd.extend(['-append', args.bootargs])
     return cmd
 
 
@@ -130,6 +132,7 @@ def main():
                         default='out/user_sifive_u')
     parser.add_argument('--debug', help='stop to wait for gdb before executing binary',
                         action='store_true')
+    parser.add_argument('--bootargs', help='pass this as bootargs to the kernel')
     args = parser.parse_args()
     run(args)
 

--- a/src/boot.s
+++ b/src/boot.s
@@ -46,6 +46,7 @@ single_core:                            # only the 1st hart past this point
         la      a0, msg_m_hello         # DEBUG print
         call    printf                  # DEBUG print
 
+        mv      a0, a1                  # a1 contains the address of FDT header, pass it to kinit
         call    kinit                   # kinit() will set up the kernel for further operations and return
 
 1:      wfi                             # after kinit() is done, halt this hart until the timer gets called, all the remaining

--- a/src/fdt.c
+++ b/src/fdt.c
@@ -1,0 +1,103 @@
+// Rudimentary implementation of the Flattened Device Tree reader as specified
+// in the Devicetree spec v0.3: https://www.devicetree.org/specifications/
+//
+// We're currently only interested in the bootargs passed on qemu command line
+// via -append flag, and we take daring shortcuts to read it.
+
+#include "fdt.h"
+#include "kernel.h"
+#include "string.h"
+
+#define NODE_CHOSEN "chosen"
+
+uint32_t bswap(uint32_t x) {
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+    uint32_t y = (x & 0x00ff00ff) << 8 | (x & 0xff00ff00) >> 8;
+    uint32_t z = (y & 0x0000ffff) << 16 | (y & 0xffff0000) >> 16;
+    return z;
+#else
+    return x
+#endif
+}
+
+// reallign a pointer to the nearest greater multiple of 4
+uint32_t* upalign4(uint32_t *x) {
+    uintptr_t addr = (uintptr_t)x;
+    addr = (addr + 3) & (-4);
+    return (uint32_t*)addr;
+}
+
+char bootargs[128];
+
+char const* fdt_get_bootargs() {
+    return bootargs;
+}
+
+void fdt_parse(uint32_t *tree, char const *strings) {
+    if (bswap(*tree) != FDT_BEGIN_NODE) {
+        return;
+    }
+    // discard root node
+    ++tree;
+    ++tree;
+    while (bswap(*tree) != FDT_BEGIN_NODE) {
+        // discard all props within the root node
+        uint32_t token = bswap(*tree++);
+        switch (token) {
+            case FDT_PROP: {
+                uint32_t len = bswap(*tree++);
+                uint32_t name_offset = bswap(*tree++);
+                tree = (uint32_t*)(((uintptr_t)tree) + len);
+                tree = upalign4(tree);
+                break;
+            }
+            case FDT_NOP:
+            case FDT_END_NODE: {
+                tree++;
+                break;
+            }
+        }
+    }
+    // now we're at the first sub-node of the root
+    tree++;
+    char const *name = (char const*)tree;
+    // make sure it's the "/chosen" node:
+    if (strncmp(name, NODE_CHOSEN, ARRAY_LENGTH(NODE_CHOSEN))) {
+        return;
+    }
+    while (*name != '\0') name++;
+    tree = (uint32_t*)name;
+    tree = upalign4(tree);
+    // now bravely assume the first prop of "/chosen" is the bootargs
+    uint32_t prop = bswap(*tree++);
+    uint32_t len = bswap(*tree++);
+    uint32_t name_offset = bswap(*tree++);
+    char const *arg = (char const*)tree;
+    strncpy(bootargs, arg, ARRAY_LENGTH(bootargs));
+}
+
+void fdt_init(uintptr_t header_addr) {
+    kprints("Reading FDT...\n");
+    fdt_header *header = (fdt_header*)header_addr;
+    if (!header) {
+        kprints("FDT is NULL, nothing to do\n");
+        return;
+    }
+    if (bswap(header->magic) != FDT_MAGIC) {
+        // TODO: change that into a return value
+        kprints("bad FDT magic\n");
+        uintptr_t m = header->magic;
+        kprintp((void*)m);
+        return;
+    }
+    if (bswap(header->last_comp_version) > FDT_VERSION) {
+        kprints("unknown FDT version\n");
+        uintptr_t v = header->version;
+        kprintp((void*)v);
+        return;
+    }
+    uint32_t *tree = (uint32_t*)(header_addr + bswap(header->off_dt_struct));
+    char const* strings = (char const*)(header_addr + bswap(header->off_dt_strings));
+    fdt_parse(tree, strings);
+    kprints("FDT ok\n");
+}

--- a/src/proc_test.c
+++ b/src/proc_test.c
@@ -1,0 +1,15 @@
+#include "proc.h"
+#include "kernel.h"
+#include "fdt.h"
+#include "string.h"
+
+void init_test_processes() {
+    if (!strncmp(fdt_get_bootargs(), "dry-run", ARRAY_LENGTH("dry-run"))) {
+        return;
+    }
+    num_procs = 2;
+    proc_table[0].pid = 0;
+    proc_table[0].pc = user_entry_point;
+    proc_table[1].pid = 1;
+    proc_table[1].pc = user_entry_point2;
+}

--- a/src/string.c
+++ b/src/string.c
@@ -1,0 +1,32 @@
+#include "string.h"
+
+int strncmp(char const *a, char const *b, unsigned int num) {
+    unsigned int i = 0;
+    do {
+        if (!*a && !*b) {
+            return 0;
+        }
+        if (!*a) {
+            return -1;
+        }
+        if (!*b) {
+            return 1;
+        }
+        if (*a != *b) {
+            break;
+        }
+        i++;
+        a++;
+        b++;
+    } while(i < num);
+    return *a - *b;
+}
+
+char* strncpy(char *dest, char const *src, unsigned int num) {
+    char *orig_dest = dest;
+    for (unsigned int i = 0; i < num - 1 && *src; i++) {
+        *dest++ = *src++;
+    }
+    *dest = '\0';
+    return orig_dest;
+}

--- a/testdata/want-output-u32.txt
+++ b/testdata/want-output-u32.txt
@@ -1,0 +1,8 @@
+Hello from M-mode!
+kinit
+Reading FDT...
+FDT ok
+bootargs: dry-run
+0000f10a
+KKKK
+qemu-launcher: killing qemu due to timeout

--- a/testdata/want-output-u64.txt
+++ b/testdata/want-output-u64.txt
@@ -1,0 +1,8 @@
+Hello from M-mode!
+kinit
+Reading FDT...
+FDT ok
+bootargs: dry-run
+000000000000f10a
+KKKK
+qemu-launcher: killing qemu due to timeout


### PR DESCRIPTION
This adds a rudimentary Flattened Device Tree reader, which allows us
accessing the command line parameters for kernel, passed via qemu's
`-append` flag.

This in turn allows specifying which test cases we want to run. This
commit adds the first such test case: a "dry run" kernel with no
userland processes.

Unfortunately, E machines don't seem to implement device trees, so no
way to run tests on them yet.