### PR TITLE
Fix bug in round-robin scheduler

### DIFF
--- a/src/kernel.c
+++ b/src/kernel.c
@@ -86,10 +86,10 @@ void kernel_timer_tick() {
 // called in interrupt_epilogue, after kernel_timer_tick() exits.
 void schedule_user_process() {
     curr_proc++;
-    if (curr_proc >= num_procs) {
+    if (num_procs == 0) {
         return;
     }
-    if (curr_proc > MAX_PROCS-1) {
+    if ((curr_proc >= MAX_PROCS) || (curr_proc >= num_procs)) {
         curr_proc = 0;
     }
     set_jump_address(proc_table[curr_proc].pc);


### PR DESCRIPTION
10628f9 has introduced a bug: our rudimentary scheduler now always
leaves one process out of the game. Fix the conditionals.