### PR TITLE
Clear the bss section before calling C codes

### DIFF
--- a/src/baremetal.ld
+++ b/src/baremetal.ld
@@ -23,10 +23,12 @@ SECTIONS
 
   . = DEFINED(ROM_START) ? RAM_START : .;
   .data : { *(.data) }
+  bss_start = .;
   .bss : {
     *(.sbss)
     *(.bss)
   }
+  bss_end = .;
   .sdata : { *(.sdata) }
   .debug : { *(.debug) }
   stack_bottom = .;

--- a/src/boot.s
+++ b/src/boot.s
@@ -34,6 +34,15 @@ _start:
 single_core:                            # only the 1st hart past this point
         la      sp, stack_top           # setup stack pointer
 
+        la      a0, bss_start
+        la      a1, bss_end
+        bgeu    a0, a1, init
+clean_bss_loop:
+        sw      zero, (a0)
+        addi    a0, a0, 4
+        bltu    a0, a1, clean_bss_loop
+init:
+
                                         # @TODO: check if user mode is supported
                                         # see: https://github.com/riscv/riscv-tests/blob/master/isa/rv64si/csr.S
                                         # OR alternatively use the trick of setting exception handler trailing the operation


### PR DESCRIPTION
Thank you for the great project at first!

I have a question here: For the .bss section, as far as I know, it will contain the area of memory used to hold static variables which must be initialized to zero. Although it may not be a big problem on the emulator(since the emulator could initialize the memory region to zero itself), I think it is still worth fixing it. Do we need to ensure the correctness by clearing the .bss section before ever calling any C codes? Or am I misunderstanding something for the question?