### PR TITLE
Disable broken integration tests

### DIFF
--- a/.github/workflows/maketest.yml
+++ b/.github/workflows/maketest.yml
@@ -19,9 +19,11 @@ jobs:
       run: riscv64-linux-gnu-gcc --version
     - name: Run virt tests
       run: make test
-    - name: Run u64 tests
-      run: make out/test-output-u64.txt
-    - name: Run u32 tests
-      run: make out/test-output-u32.txt
+# Disable broken tests for now:
+#
+#     - name: Run u64 tests
+#       run: make out/test-output-u64.txt
+#     - name: Run u32 tests
+#       run: make out/test-output-u32.txt
     - name: Make all binaries
       run: make all


### PR DESCRIPTION
The tests based on qemu-launcher.py seem to be broken now, I'm disabling
them to avoid noise from Github actions.

Filed #43 to investigate further.