### PR TITLE
Fix build: parameter parsing via FDT got broken

### DIFF
--- a/src/boot.s
+++ b/src/boot.s
@@ -34,13 +34,13 @@ _start:
 single_core:                            # only the 1st hart past this point
         la      sp, stack_top           # setup stack pointer
 
-        la      a0, bss_start
-        la      a1, bss_end
-        bgeu    a0, a1, init
+        la      t0, bss_start
+        la      t1, bss_end
+        bgeu    t0, t1, init
 clean_bss_loop:
-        sw      zero, (a0)
-        addi    a0, a0, 4
-        bltu    a0, a1, clean_bss_loop
+        sw      zero, (t0)
+        addi    t0, t0, 4
+        bltu    t0, t1, clean_bss_loop
 init:
 
                                         # @TODO: check if user mode is supported


### PR DESCRIPTION
c2fbe93 has introduced zeroing out of bss section, which trashes a1
register, which contains the address of FDT header on boot. The fix is
trivial: replace a0/a1 with t0/t1.

The breakage should've been caught by Github actions, but they don't run
automatically for the first-time contributors, and that's how it went
unnoticed.