### PR TITLE
Rewrite hart sync code during early boot

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -137,38 +137,45 @@ $(OUT)/test_sifive_u: ${TEST_SIFIVE_U_DEPS}
 
 $(OUT)/user_sifive_u: ${USER_SIFIVE_U_DEPS}
 	$(RISCV64_GCC) -march=rv64g -mabi=lp64 $(GCC_FLAGS) \
+		-Wa,--defsym,NUM_HARTS=2 \
 		${USER_SIFIVE_U_DEPS} -o $@
 
 $(OUT)/test_sifive_u32: ${TEST_SIFIVE_U32_DEPS}
 	$(RISCV64_GCC) -march=rv32g -mabi=ilp32 $(GCC_FLAGS) \
 		-Wa,--defsym,XLEN=32 \
+		-Wa,--defsym,NUM_HARTS=1 \
 		${TEST_SIFIVE_U32_DEPS} -o $@
 
 $(OUT)/user_sifive_u32: ${USER_SIFIVE_U32_DEPS}
 	$(RISCV64_GCC) -march=rv32g -mabi=ilp32 $(GCC_FLAGS) \
 		-Wa,--defsym,XLEN=32 \
+		-Wa,--defsym,NUM_HARTS=2 \
 		${USER_SIFIVE_U32_DEPS} -o $@
 
 $(OUT)/test_sifive_e: ${TEST_SIFIVE_E_DEPS}
 	$(RISCV64_GCC) -march=rv64g -mabi=lp64 $(GCC_FLAGS) \
 		-Wl,--defsym,ROM_START=0x20400000 -Wa,--defsym,UART=0x10013000 \
+		-Wa,--defsym,NUM_HARTS=1 \
 		${TEST_SIFIVE_E_DEPS} -o $@
 
 $(OUT)/user_sifive_e: ${USER_SIFIVE_E_DEPS}
 	$(RISCV64_GCC) -march=rv64g -mabi=lp64 $(GCC_FLAGS) \
 		-Wl,--defsym,ROM_START=0x20400000 -Wa,--defsym,UART=0x10013000 \
+		-Wa,--defsym,NUM_HARTS=1 \
 		${USER_SIFIVE_E_DEPS} -o $@
 
 $(OUT)/test_sifive_e32: ${TEST_SIFIVE_E32_DEPS}
 	$(RISCV64_GCC) -march=rv32g -mabi=ilp32 $(GCC_FLAGS) \
 		-Wl,--defsym,ROM_START=0x20400000 -Wa,--defsym,UART=0x10013000 \
 		-Wa,--defsym,XLEN=32 \
+		-Wa,--defsym,NUM_HARTS=1 \
 		${TEST_SIFIVE_E32_DEPS} -o $@
 
 $(OUT)/user_sifive_e32: ${USER_SIFIVE_E32_DEPS}
 	$(RISCV64_GCC) -march=rv32g -mabi=ilp32 $(GCC_FLAGS) \
 		-Wl,--defsym,ROM_START=0x20400000 -Wa,--defsym,UART=0x10013000 \
 		-Wa,--defsym,XLEN=32 \
+		-Wa,--defsym,NUM_HARTS=1 \
 		${USER_SIFIVE_E32_DEPS} -o $@
 
 $(OUT)/test_virt: ${TEST_VIRT_DEPS}
@@ -179,12 +186,13 @@ $(OUT)/test_virt: ${TEST_VIRT_DEPS}
 $(OUT)/user_virt: ${USER_VIRT_DEPS}
 	$(RISCV64_GCC) -march=rv64g -mabi=lp64 $(GCC_FLAGS) \
 		-Wa,--defsym,UART=0x10000000 -Wa,--defsym,QEMU_EXIT=0x100000 \
+		-Wa,--defsym,NUM_HARTS=1 \
 		${USER_VIRT_DEPS} -o $@
 
 $(OUT)/user_hifive1_revb: ${USER_SIFIVE_E32_DEPS}
 	$(RISCV64_GCC) -march=rv32imac -mabi=ilp32 $(GCC_FLAGS) \
 		-Wl,--defsym,ROM_START=0x20010000 -Wa,--defsym,UART=0x10013000 \
-		-Wa,--defsym,XLEN=32 -Wa,--defsym,NO_S_MODE=1 \
+		-Wa,--defsym,XLEN=32 -Wa,--defsym,NO_S_MODE=1 -Wa,--defsym,NUM_HARTS=1 \
 		${USER_SIFIVE_E32_DEPS} -o $@
 
 $(OUT):


### PR DESCRIPTION
We used to use an atomic op, but that's unreliable while memory segments
are not init'ed: works fine on qemu, but will not work on physical
hardware.

This new approach avoids using main memory for synchronizing harts. It
hardcodes the 0th hart to be responsible for init'ing the memory
segments. Other harts spin a busy loop while the boot hart is done with
it. The harts communicate via MSIP register, which allows reliable
signalling between harts.

The approach is taken from the Freedom SDK CRT code.