### PR TITLE
Make it run on HiFive1 Rev B

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -138,30 +138,35 @@ $(OUT)/test_sifive_u: ${TEST_SIFIVE_U_DEPS}
 $(OUT)/user_sifive_u: ${USER_SIFIVE_U_DEPS}
 	$(RISCV64_GCC) -march=rv64g -mabi=lp64 $(GCC_FLAGS) \
 		-Wa,--defsym,NUM_HARTS=2 \
+		-include include/machine/qemu.h \
 		${USER_SIFIVE_U_DEPS} -o $@
 
 $(OUT)/test_sifive_u32: ${TEST_SIFIVE_U32_DEPS}
 	$(RISCV64_GCC) -march=rv32g -mabi=ilp32 $(GCC_FLAGS) \
 		-Wa,--defsym,XLEN=32 \
 		-Wa,--defsym,NUM_HARTS=1 \
+		-include include/machine/qemu.h \
 		${TEST_SIFIVE_U32_DEPS} -o $@
 
 $(OUT)/user_sifive_u32: ${USER_SIFIVE_U32_DEPS}
 	$(RISCV64_GCC) -march=rv32g -mabi=ilp32 $(GCC_FLAGS) \
 		-Wa,--defsym,XLEN=32 \
 		-Wa,--defsym,NUM_HARTS=2 \
+		-include include/machine/qemu.h \
 		${USER_SIFIVE_U32_DEPS} -o $@
 
 $(OUT)/test_sifive_e: ${TEST_SIFIVE_E_DEPS}
 	$(RISCV64_GCC) -march=rv64g -mabi=lp64 $(GCC_FLAGS) \
 		-Wl,--defsym,ROM_START=0x20400000 -Wa,--defsym,UART=0x10013000 \
 		-Wa,--defsym,NUM_HARTS=1 \
+		-include include/machine/qemu.h \
 		${TEST_SIFIVE_E_DEPS} -o $@
 
 $(OUT)/user_sifive_e: ${USER_SIFIVE_E_DEPS}
 	$(RISCV64_GCC) -march=rv64g -mabi=lp64 $(GCC_FLAGS) \
 		-Wl,--defsym,ROM_START=0x20400000 -Wa,--defsym,UART=0x10013000 \
 		-Wa,--defsym,NUM_HARTS=1 \
+		-include include/machine/qemu.h \
 		${USER_SIFIVE_E_DEPS} -o $@
 
 $(OUT)/test_sifive_e32: ${TEST_SIFIVE_E32_DEPS}
@@ -169,6 +174,7 @@ $(OUT)/test_sifive_e32: ${TEST_SIFIVE_E32_DEPS}
 		-Wl,--defsym,ROM_START=0x20400000 -Wa,--defsym,UART=0x10013000 \
 		-Wa,--defsym,XLEN=32 \
 		-Wa,--defsym,NUM_HARTS=1 \
+		-include include/machine/qemu.h \
 		${TEST_SIFIVE_E32_DEPS} -o $@
 
 $(OUT)/user_sifive_e32: ${USER_SIFIVE_E32_DEPS}
@@ -176,23 +182,27 @@ $(OUT)/user_sifive_e32: ${USER_SIFIVE_E32_DEPS}
 		-Wl,--defsym,ROM_START=0x20400000 -Wa,--defsym,UART=0x10013000 \
 		-Wa,--defsym,XLEN=32 \
 		-Wa,--defsym,NUM_HARTS=1 \
+		-include include/machine/qemu.h \
 		${USER_SIFIVE_E32_DEPS} -o $@
 
 $(OUT)/test_virt: ${TEST_VIRT_DEPS}
 	$(RISCV64_GCC) -march=rv64g -mabi=lp64 $(GCC_FLAGS) \
 		-Wa,--defsym,UART=0x10000000 -Wa,--defsym,QEMU_EXIT=0x100000 \
+		-include include/machine/qemu.h \
 		${TEST_VIRT_DEPS} -o $@
 
 $(OUT)/user_virt: ${USER_VIRT_DEPS}
 	$(RISCV64_GCC) -march=rv64g -mabi=lp64 $(GCC_FLAGS) \
 		-Wa,--defsym,UART=0x10000000 -Wa,--defsym,QEMU_EXIT=0x100000 \
 		-Wa,--defsym,NUM_HARTS=1 \
+		-include include/machine/qemu.h \
 		${USER_VIRT_DEPS} -o $@
 
 $(OUT)/user_hifive1_revb: ${USER_SIFIVE_E32_DEPS}
 	$(RISCV64_GCC) -march=rv32imac -mabi=ilp32 $(GCC_FLAGS) \
 		-Wl,--defsym,ROM_START=0x20010000 -Wa,--defsym,UART=0x10013000 \
 		-Wa,--defsym,XLEN=32 -Wa,--defsym,NO_S_MODE=1 -Wa,--defsym,NUM_HARTS=1 \
+		-include include/machine/hifive1-revb.h \
 		${USER_SIFIVE_E32_DEPS} -o $@
 
 $(OUT):

--- a/include/kernel.h
+++ b/include/kernel.h
@@ -4,11 +4,6 @@
 #include "riscv.h"
 #include "pmp.h"
 
-// Based on SIFIVE_CLINT_TIMEBASE_FREQ = 10000000 value from QEMU SiFive CLINT
-// implementation:
-// https://github.com/qemu/qemu/blob/master/include/hw/intc/sifive_clint.h
-#define ONE_SECOND        10*1000*1000
-
 #define KERNEL_SCHEDULER_TICK_TIME (ONE_SECOND)
 
 void kinit(uintptr_t fdt_header_addr);

--- a/include/machine/hifive1-revb.h
+++ b/include/machine/hifive1-revb.h
@@ -1,0 +1,13 @@
+#ifndef _HIFIVE1_REVB_
+#define _HIFIVE1_REVB_
+
+// SiFive FE310-G002 Manual v1p1
+// Chapter 16 - Real-Time Clock (RTC)
+//
+// "The real-time clock (RTC) is located in the always-on domain, and is clocked
+// by a selectable low-frequency clock source. For best accuracy, the RTC should
+// be driven by an external 32.768 kHz watch crystal oscillator, but to reduce
+// system cost, can be driven by a factorytrimmed on-chip oscillator."
+#define ONE_SECOND 32768
+
+#endif // ifndef _HIFIVE1_REVB_

--- a/include/machine/qemu.h
+++ b/include/machine/qemu.h
@@ -1,0 +1,9 @@
+#ifndef _QEMU_H_
+#define _QEMU_H_
+
+// Based on SIFIVE_CLINT_TIMEBASE_FREQ = 10000000 value from QEMU SiFive CLINT
+// implementation:
+// https://github.com/qemu/qemu/blob/master/include/hw/intc/sifive_clint.h
+#define ONE_SECOND        (10*1000*1000)
+
+#endif // ifndef _QEMU_H_

--- a/src/boot.s
+++ b/src/boot.s
@@ -181,38 +181,68 @@ early_trap_vector:
                                         # > the first instruction that has not completed yet. Thus, when returning from the interrupt handler,
                                         # > the execution continues exactly where it was interrupted.
 .globl trap_vector
+.balign 64
 trap_vector:                            # 3.1.20 Machine Cause Register (mcause), Table 3.6: Machine cause register (mcause) values after trap.
         j exception_dispatch            #  0: user software interrupt OR _exception_ (See note in 3.1.12: Machine Trap-Vector Base-Address Register)
+.balign 4
         j interrupt_noop                #  1: supervisor software interrupt
+.balign 4
         j interrupt_noop                #  2: reserved
+.balign 4
         j interrupt_noop                #  3: machine software interrupt
+.balign 4
         j interrupt_timer               #  4: user timer interrupt
+.balign 4
         j interrupt_timer               #  5: supervisor timer interrupt
+.balign 4
         j interrupt_noop                #  6: reserved
+.balign 4
         j k_interrupt_timer             #  7: machine timer interrupt
+.balign 4
         j interrupt_noop                #  8: user external interrupt
+.balign 4
         j interrupt_noop                #  9: supervisor external interrupt
+.balign 4
         j interrupt_noop                # 10: reserved
+.balign 4
         j interrupt_noop                # 11: machine external interrupt
 
 exception_vector:                       # 3.1.20 Machine Cause Register (mcause), Table 3.6: Machine cause register (mcause) values after trap.
+.balign 4
         j exception                     #  0: instruction address misaligned
+.balign 4
         j exception                     #  1: instruction access fault
+.balign 4
         j exception                     #  2: illegal instruction
+.balign 4
         j exception                     #  3: breakpoint
+.balign 4
         j exception                     #  4: load address misaligned
+.balign 4
         j exception                     #  5: load access fault
+.balign 4
         j exception                     #  6: store/AMO address misaligned
+.balign 4
         j exception                     #  7: store/AMO access fault
+.balign 4
         j syscall_dispatch              #  8: environment call from U-mode
+.balign 4
         j syscall_dispatch              #  9: environment call from S-mode
+.balign 4
         j exception                     # 10: reserved
+.balign 4
         j syscall_dispatch              # 11: environment call from M-mode
+.balign 4
         j exception                     # 12: instruction page fault
+.balign 4
         j exception                     # 13: load page fault
+.balign 4
         j exception                     # 14: reserved
+.balign 4
         j exception                     # 15: store/AMO page fault
+.balign 4
         j exception                     # 16: reserved
+.balign 4
 exception_vector_end:
 
 exception_dispatch:

--- a/src/syscalls.c
+++ b/src/syscalls.c
@@ -4,7 +4,12 @@
 
 // for fun let's pretend syscall table is kinda like 32bit Linux on x86,
 // /usr/include/asm/unistd_32.h: __NR_restart_syscall 0, __NR_exit 1, _NR_fork 2, __NR_read 3, __NR_write 4
-void *syscall_vector[] = {
+//
+// Note that we place syscall_vector in a .text segment in order to have it in
+// ROM, since it's read-only after all. We also specify the section with a
+// trailing # in order to avoid a warning from GCC, see this answer:
+// https://stackoverflow.com/a/58455496/6763
+void __attribute__((__section__(".text#"))) *syscall_vector[] = {
 /* 0 */     sys_restart,
 /* 1 */     sys_exit,
 /* 2 */     sys_fork,

--- a/src/userland.c
+++ b/src/userland.c
@@ -1,7 +1,7 @@
 #include "sys.h"
 #include "userland.h"
 
-#define PRINT_FREQ (10*1000*1000)
+#define PRINT_FREQ ONE_SECOND
 
 uint64_t get_clock_cycles();
 int m_read_hart_id();
@@ -13,6 +13,7 @@ int _userland u_main() {
     uint64_t clock_cycles = get_clock_cycles();
     sys_puts("OK\n");
 
+    /*
     sys_puts("Read from memory: ");
     int word = *a_string_in_user_mem_ptr;
     sys_puts("OK\n");
@@ -39,6 +40,7 @@ int _userland u_main() {
     sys_puts("Illegal read from protected memory: ");
     // causes Load access fault (mcause=5) in User mode:
     word = *msg_m_hello_ptr;
+    */
 
     int counter = 0;
     int flipper = 0;
@@ -65,6 +67,7 @@ int _userland u_main2() {
     uint64_t clock_cycles = get_clock_cycles();
     sys_puts("OK\n");
 
+    /*
     sys_puts("Read from memory: ");
     int word = *a_string_in_user_mem_ptr;
     sys_puts("OK\n");
@@ -91,6 +94,7 @@ int _userland u_main2() {
     sys_puts("Illegal read from protected memory: ");
     // causes Load access fault (mcause=5) in User mode:
     word = *msg_m_hello_ptr;
+    */
 
     int counter = 0;
     int flipper = 0;


### PR DESCRIPTION
There were two major problems with our code on HiFive: wrong trap_vector
and wrong syscall_vector.

Trap vector had two problems of its own: first, on HiFive a vectored
trap vectored is required to be aligned to 64 bytes. Second, with
compact instructions the vector was too dense, so we need to align each
entry to 4 bytes as well. Did the same for exception_vector as well.

The problem with syscall vector was different: the global variable got
placed in a .data segment by default, as it should be. But we're still
missing code that copies .data segment from ROM to RAM, so in effect the
vector was garbage. As a quick fix I moved syscall_vector to .text, as
it's meant to be read-only anyway.

Finally, a couple minor fixes: moved the clock freq definition to
machine-specific headers, as they differ on QEMU and HiFive. Also,
commented out some noisy stuff from userland code. I will factor it out
to some dedicated test later.