### PR TITLE
Reenable integration tests

### DIFF
--- a/.github/workflows/maketest.yml
+++ b/.github/workflows/maketest.yml
@@ -19,11 +19,9 @@ jobs:
       run: riscv64-linux-gnu-gcc --version
     - name: Run virt tests
       run: make test
-# Disable broken tests for now:
-#
-#     - name: Run u64 tests
-#       run: make out/test-output-u64.txt
-#     - name: Run u32 tests
-#       run: make out/test-output-u32.txt
+    - name: Run u64 tests
+      run: make out/test-output-u64.txt
+    - name: Run u32 tests
+      run: make out/test-output-u32.txt
     - name: Make all binaries
       run: make all

--- a/Makefile
+++ b/Makefile
@@ -129,6 +129,7 @@ gdb:
 
 GCC_FLAGS=-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles \
           -ffreestanding \
+          -fno-plt -fno-pic \
           -Tsrc/baremetal.ld -Iinclude
 
 $(OUT)/test_sifive_u: ${TEST_SIFIVE_U_DEPS}


### PR DESCRIPTION
The problem was the new GCC version building with Global Offset Table by
default, which was causing a NULL pointer dereference. This was
happening very early in FDT parsing code, where our normal trap vector
is not set up yet, so it was jumping to the early_trap_vector, which
deadloops.

Added `no-plt` and `no-pic` flags to address this.

Fixes #43.