### PR TITLE
Implement proper kprintf, drop other half-assed helpers

### DIFF
--- a/include/kernel.h
+++ b/include/kernel.h
@@ -19,12 +19,17 @@ void enable_interrupts();
 void set_timer_after(uint64_t delta);
 
 // implemented in boot.s
-void kprints(char const *msg, ...);
+// NOTE: gcc has a neat attribute, like this:
+//     void kprintf(char const *msg, ...) __attribute__ ((format (printf, 1, 2)));
+// with it, we'd get compile-time checks for format string compatibility with
+// the args. However, that check is obviously very strict and demands me to use,
+// e.g. %lx instead of %x on rv32. I don't want to bother with that at this
+// point, so will just leave this note here as a reminder and we can implement
+// it later.
+// (docs: https://gcc.gnu.org/onlinedocs/gcc-3.2/gcc/Function-Attributes.html)
+void kprintf(char const *msg, ...);
 
-// implemented in kernel.c
-void kprintp(void* p);
-void kprintul(unsigned long i);
-
+// implemented in userland.c
 extern void user_entry_point();
 extern void user_entry_point2();
 

--- a/src/baremetal-print.s
+++ b/src/baremetal-print.s
@@ -14,7 +14,7 @@ MACHINE NOT SUPPORTED!
 .section .text
 .global printf                          # C-like print formatted string. Supports formatting: %s, %c, %d, %i, %u, %x, %o, %p
                                         # @param[in] a0 address of NULL terminated formatted string,
-                                        # @param[in] a1 address of argmuments
+                                        # @param[in] a1 address of arguments
 
 .global prints                          # Print string.
                                         # @param[in] a0 address of NULL terminated string
@@ -63,7 +63,7 @@ printf:
 3:      lw      t1, UART_REG_TXFIFO(t2) # read from serial
         bltz    t1, 3b                  # until >= 0
         sw      t0, UART_REG_TXFIFO(t2) # write to serial
-        addi    a0, a0, 1               # increment a6
+        addi    a0, a0, 1               # increment a0
         j       0b                      # continue
 
 10:     addi    a0, a0, 2

--- a/src/boot.s
+++ b/src/boot.s
@@ -353,13 +353,25 @@ k_interrupt_timer:
         call    kernel_timer_tick
         j       interrupt_epilogue
 
-.globl kprints
-kprints:
-        stackalloc_x 1
-        sx      ra, 1, (sp)
+# kprintf is called with args in a0..a7, but printf expects to get fmt string
+# in a0 and a pointer to the rest of args in a1. So push a1..a7 to stack and
+# pass a pointer to that location in a1.
+.globl kprintf
+kprintf:
+        stackalloc_x 8
+        mv      t0, sp
+        sx      a1, 0, (sp)
+        sx      a2, 1, (sp)
+        sx      a3, 2, (sp)
+        sx      a4, 3, (sp)
+        sx      a5, 4, (sp)
+        sx      a6, 5, (sp)
+        sx      a7, 6, (sp)
+        sx      ra, 7, (sp)
+        mv      a1, t0
         call    printf
-        lx      ra, 1, (sp)
-        stackfree_x 1
+        lx      ra, 7, (sp)
+        stackfree_x 8
         ret
 
 .globl park_hart

--- a/src/fdt.c
+++ b/src/fdt.c
@@ -77,27 +77,23 @@ void fdt_parse(uint32_t *tree, char const *strings) {
 }
 
 void fdt_init(uintptr_t header_addr) {
-    kprints("Reading FDT...\n");
+    kprintf("Reading FDT...\n");
     fdt_header *header = (fdt_header*)header_addr;
     if (!header) {
-        kprints("FDT is NULL, nothing to do\n");
+        kprintf("FDT is NULL, nothing to do\n");
         return;
     }
     if (bswap(header->magic) != FDT_MAGIC) {
         // TODO: change that into a return value
-        kprints("bad FDT magic\n");
-        uintptr_t m = header->magic;
-        kprintp((void*)m);
+        kprintf("bad FDT magic: %x\n", header->magic);
         return;
     }
     if (bswap(header->last_comp_version) > FDT_VERSION) {
-        kprints("unknown FDT version\n");
-        uintptr_t v = header->version;
-        kprintp((void*)v);
+        kprintf("unknown FDT version: %x\n", header->version);
         return;
     }
     uint32_t *tree = (uint32_t*)(header_addr + bswap(header->off_dt_struct));
     char const* strings = (char const*)(header_addr + bswap(header->off_dt_strings));
     fdt_parse(tree, strings);
-    kprints("FDT ok\n");
+    kprintf("FDT ok\n");
 }

--- a/testdata/want-output-u32.txt
+++ b/testdata/want-output-u32.txt
@@ -1,8 +1,8 @@
-kinit: cpu 00000000
+kinit: cpu 0
 Reading FDT...
 FDT ok
 bootargs: dry-run
-0000f10a
-cpu parked: 00000001
+kprintf test several params: foo, 0xF10A, 0
+cpu parked: 1
 KKKK
 qemu-launcher: killing qemu due to timeout

--- a/testdata/want-output-u64.txt
+++ b/testdata/want-output-u64.txt
@@ -1,8 +1,8 @@
-kinit: cpu 0000000000000000
+kinit: cpu 0
 Reading FDT...
 FDT ok
 bootargs: dry-run
-000000000000f10a
-cpu parked: 0000000000000001
+kprintf test several params: foo, 0xF10A, 0
+cpu parked: 1
 KKKK
 qemu-launcher: killing qemu due to timeout


### PR DESCRIPTION
We already have `printf` implemented, but we needed a calling convention
adapter.

We no longer need `kprints`, `kprintp` and `kprintul`, so ditch them.