### PR TITLE
Cleanup: move more process-related code together

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ TEST_DEPS = src/baremetal-fib.s src/baremetal-print.s src/baremetal-poweroff.s
 USER_DEPS = src/boot.s src/baremetal-print.s \
 			src/baremetal-poweroff.s src/userland.c src/kernel.c src/syscalls.c \
 			src/pmp.c src/riscv.c src/fdt.c src/string.c src/proc_test.c \
-			src/spinlock.c
+			src/spinlock.c src/proc.c
 TEST_SIFIVE_U_DEPS = $(TEST_DEPS)
 USER_SIFIVE_U_DEPS = $(USER_DEPS)
 TEST_SIFIVE_E_DEPS = $(TEST_DEPS)

--- a/include/kernel.h
+++ b/include/kernel.h
@@ -12,11 +12,7 @@
 #define KERNEL_SCHEDULER_TICK_TIME (ONE_SECOND)
 
 void kinit(uintptr_t fdt_header_addr);
-void init_process_table();
 void init_trap_vector();
-void schedule_user_process();
-void set_user_mode();
-void set_jump_address(void *func);
 void kernel_timer_tick();
 void set_timer();
 void disable_interrupts();

--- a/include/proc.h
+++ b/include/proc.h
@@ -1,7 +1,7 @@
 #ifndef _PROC_H_
 #define _PROC_H_
 
-// TODO: move other process-related stuff here
+#include "riscv.h"
 
 #define MAX_PROCS 2
 
@@ -12,10 +12,13 @@ typedef struct process_s {
 
 extern process_t proc_table[MAX_PROCS];
 extern int num_procs;
+extern int curr_proc;
 
 // init_test_processes initializes the process table with a set of userland
 // processes that will get executed by default. Kind of like what an initrd
 // would do, but a poor man's version until we can do better.
 void init_test_processes();
+void init_process_table();
+void schedule_user_process();
 
 #endif // ifndef _PROC_H_

--- a/include/riscv.h
+++ b/include/riscv.h
@@ -3,6 +3,9 @@
 
 #include "sys.h"
 
+// An arbitrary limit, as of now:
+#define MAX_HARTS 4
+
 // 1.3 Privilege Levels, Table 1.1: RISC-V privilege levels.
 #define MODE_U      0 << 11
 #define MODE_S      1 << 11
@@ -30,6 +33,9 @@ void set_pmpaddr1(void* addr);
 void set_pmpaddr2(void* addr);
 void set_pmpaddr3(void* addr);
 void set_pmpcfg0(unsigned long value);
+
+void set_user_mode();
+void set_jump_address(void *func);
 
 // implemented in boot.s
 void park_hart();

--- a/src/kernel.c
+++ b/src/kernel.c
@@ -4,10 +4,6 @@
 #include "proc.h"
 #include "fdt.h"
 
-process_t proc_table[MAX_PROCS];
-int curr_proc = 0;
-int num_procs = 0;
-
 spinlock init_lock = 0;
 
 void kinit(uintptr_t fdt_header_addr) {
@@ -79,93 +75,6 @@ void kernel_timer_tick() {
     set_timer_after(KERNEL_SCHEDULER_TICK_TIME);
     schedule_user_process();
     enable_interrupts();
-}
-
-// 3.1.7 Privilege and Global Interrupt-Enable Stack in mstatus register
-// > The MRET, SRET, or URET instructions are used to return from traps in
-// > M-mode, S-mode, or U-mode respectively. When executing an xRET instruction,
-// > supposing x PP holds the value y, x IE is set to xPIE; the privilege mode
-// > is changed to > y; xPIE is set to 1; and xPP is set to U (or M if user-mode
-// > is not supported).
-//
-// 3.2.2 Trap-Return Instructions
-// > An xRET instruction can be executed in privilege mode x or higher,
-// > where executing a lower-privilege xRET instruction will pop
-// > the relevant lower-privilege interrupt enable and privilege mode stack.
-// > In addition to manipulating the privilege stack as described in Section
-// > 3.1.7, xRET sets the pc to the value stored in the x epc register.
-//
-// Use MRET instruction to switch privilege level from Machine (M-mode) to User
-// (U-mode). MRET will change privilege to Machine Previous Privilege stored in
-// mstatus CSR and jump to Machine Exception Program Counter specified by mepc
-// CSR.
-//
-// schedule_user_process() is only called from kernel_timer_tick(), and MRET is
-// called in interrupt_epilogue, after kernel_timer_tick() exits.
-void schedule_user_process() {
-    curr_proc++;
-    if (num_procs == 0) {
-        return;
-    }
-    if ((curr_proc >= MAX_PROCS) || (curr_proc >= num_procs)) {
-        curr_proc = 0;
-    }
-    set_jump_address(proc_table[curr_proc].pc);
-    set_user_mode();
-}
-
-// TODO: move to proc.c
-void init_process_table() {
-    init_test_processes();
-    // init curr_proc to -1, it will get incremented to 0 on the first
-    // scheduler run. This will also help to identify the very first call to
-    // kernel_timer_tick, which will happen from the kernel land. We want to
-    // know that so we can discard the kernel code pc that we get on that first
-    // call.
-    curr_proc = -1;
-}
-
-// Privilege levels are encoded in 2 bits: User = 0b00, Supervisor = 0b01,
-// Machine = 0b11 and stored in 11:12 bits of mstatus CSR (called mstatus.mpp)
-void set_user_mode() {
-    unsigned int mstatus = get_mstatus();
-    mstatus &= MODE_MASK;   // zero out mode bits 11:12
-    mstatus |= MODE_U;      // set them to user mode
-    set_mstatus(mstatus);
-}
-
-unsigned int get_mstatus() {
-    register unsigned int a0 asm ("a0");
-    asm volatile (
-        "csrr a0, mstatus"
-        : "=r"(a0)   // output in a0
-    );
-    return a0;
-}
-
-void set_mstatus(unsigned int value) {
-    asm volatile (
-        "csrw mstatus, %0"
-        :            // no output
-        : "r"(value) // input in value
-    );
-}
-
-void* get_mepc() {
-    register void* a0 asm ("a0");
-    asm volatile (
-        "csrr a0, mepc"
-        : "=r"(a0)   // output in a0
-    );
-    return a0;
-}
-
-void set_jump_address(void *func) {
-    asm volatile (
-        "csrw   mepc, %0;"  // set mepc to userland function
-        :                   // no output
-        : "r"(func)         // input in func
-    );
 }
 
 void set_timer_after(uint64_t delta) {

--- a/src/proc.c
+++ b/src/proc.c
@@ -1,0 +1,48 @@
+#include "proc.h"
+
+process_t proc_table[MAX_PROCS];
+int curr_proc = 0;
+int num_procs = 0;
+
+void init_process_table() {
+    init_test_processes();
+    // init curr_proc to -1, it will get incremented to 0 on the first
+    // scheduler run. This will also help to identify the very first call to
+    // kernel_timer_tick, which will happen from the kernel land. We want to
+    // know that so we can discard the kernel code pc that we get on that first
+    // call.
+    curr_proc = -1;
+}
+
+// 3.1.7 Privilege and Global Interrupt-Enable Stack in mstatus register
+// > The MRET, SRET, or URET instructions are used to return from traps in
+// > M-mode, S-mode, or U-mode respectively. When executing an xRET instruction,
+// > supposing x PP holds the value y, x IE is set to xPIE; the privilege mode
+// > is changed to > y; xPIE is set to 1; and xPP is set to U (or M if user-mode
+// > is not supported).
+//
+// 3.2.2 Trap-Return Instructions
+// > An xRET instruction can be executed in privilege mode x or higher,
+// > where executing a lower-privilege xRET instruction will pop
+// > the relevant lower-privilege interrupt enable and privilege mode stack.
+// > In addition to manipulating the privilege stack as described in Section
+// > 3.1.7, xRET sets the pc to the value stored in the x epc register.
+//
+// Use MRET instruction to switch privilege level from Machine (M-mode) to User
+// (U-mode). MRET will change privilege to Machine Previous Privilege stored in
+// mstatus CSR and jump to Machine Exception Program Counter specified by mepc
+// CSR.
+//
+// schedule_user_process() is only called from kernel_timer_tick(), and MRET is
+// called in interrupt_epilogue, after kernel_timer_tick() exits.
+void schedule_user_process() {
+    curr_proc++;
+    if (num_procs == 0) {
+        return;
+    }
+    if ((curr_proc >= MAX_PROCS) || (curr_proc >= num_procs)) {
+        curr_proc = 0;
+    }
+    set_jump_address(proc_table[curr_proc].pc);
+    set_user_mode();
+}

--- a/src/riscv.c
+++ b/src/riscv.c
@@ -57,3 +57,46 @@ void set_pmpcfg0(unsigned long value) {
         : "r"(value)            // input in value
     );
 }
+
+unsigned int get_mstatus() {
+    register unsigned int a0 asm ("a0");
+    asm volatile (
+        "csrr a0, mstatus"
+        : "=r"(a0)   // output in a0
+    );
+    return a0;
+}
+
+void set_mstatus(unsigned int value) {
+    asm volatile (
+        "csrw mstatus, %0"
+        :            // no output
+        : "r"(value) // input in value
+    );
+}
+
+void* get_mepc() {
+    register void* a0 asm ("a0");
+    asm volatile (
+        "csrr a0, mepc"
+        : "=r"(a0)   // output in a0
+    );
+    return a0;
+}
+
+void set_jump_address(void *func) {
+    asm volatile (
+        "csrw   mepc, %0;"  // set mepc to userland function
+        :                   // no output
+        : "r"(func)         // input in func
+    );
+}
+
+// Privilege levels are encoded in 2 bits: User = 0b00, Supervisor = 0b01,
+// Machine = 0b11 and stored in 11:12 bits of mstatus CSR (called mstatus.mpp)
+void set_user_mode() {
+    unsigned int mstatus = get_mstatus();
+    mstatus &= MODE_MASK;   // zero out mode bits 11:12
+    mstatus |= MODE_U;      // set them to user mode
+    set_mstatus(mstatus);
+}


### PR DESCRIPTION
Incidentally, move some low-level RISC-V-specific code to riscv.c.