### PR TITLE
Improve context switching: save all userland registers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ TEST_DEPS = src/baremetal-fib.s src/baremetal-print.s src/baremetal-poweroff.s
 USER_DEPS = src/boot.s src/baremetal-print.s \
 			src/baremetal-poweroff.s src/userland.c src/kernel.c src/syscalls.c \
 			src/pmp.c src/riscv.c src/fdt.c src/string.c src/proc_test.c \
-			src/spinlock.c src/proc.c src/usyscalls.s
+			src/spinlock.c src/proc.c src/usyscalls.s src/context.s
 TEST_SIFIVE_U_DEPS = $(TEST_DEPS)
 USER_SIFIVE_U_DEPS = $(USER_DEPS)
 TEST_SIFIVE_E_DEPS = $(TEST_DEPS)

--- a/include/kernel.h
+++ b/include/kernel.h
@@ -3,6 +3,7 @@
 
 #include "riscv.h"
 #include "pmp.h"
+#include "proc.h"
 
 #define KERNEL_SCHEDULER_TICK_TIME (ONE_SECOND)
 

--- a/include/proc.h
+++ b/include/proc.h
@@ -6,14 +6,36 @@
 
 #define MAX_PROCS 2
 
+// REG_* constants are indexes into trap_frame_t.regs. (Add here as needed)
+#define REG_RA 0
+#define REG_SP 1
+
+typedef struct trap_frame_s {
+    regsize_t regs[32];
+} trap_frame_t;
+
 typedef struct process_s {
     uint32_t pid;
     void *pc;
+    trap_frame_t context;
 } process_t;
 
 extern process_t proc_table[MAX_PROCS];
 extern int num_procs;
 extern int curr_proc;
+
+// trap_frame is the piece of memory to hold all user registers when we enter
+// the trap. When the scheduler picks the new process to run, it will save
+// trap_frame in the process_t of the old process and will populate trap_frame
+// with the new process's context.
+//
+// When we're ready to return to userland, trap_frame is expected to already
+// contain everything the userland needs to have. In case of a fresh process, it
+// needs to have at least regs[REG_SP] populated.
+//
+// In between the traps mscratch will point here so that we can save user
+// registers without trashing any.
+extern trap_frame_t trap_frame;
 
 // init_test_processes initializes the process table with a set of userland
 // processes that will get executed by default. Kind of like what an initrd
@@ -21,5 +43,9 @@ extern int curr_proc;
 void init_test_processes();
 void init_process_table();
 void schedule_user_process();
+
+// init_global_trap_frame makes sure that mscratch contains a pointer to
+// trap_frame before the first userland process gets scheduled.
+void init_global_trap_frame();
 
 #endif // ifndef _PROC_H_

--- a/include/riscv.h
+++ b/include/riscv.h
@@ -36,6 +36,7 @@ void set_pmpcfg0(unsigned long value);
 
 void set_user_mode();
 void set_jump_address(void *func);
+void set_mscratch(void* ptr);
 
 // implemented in boot.s
 void park_hart();

--- a/include/sys.h
+++ b/include/sys.h
@@ -9,12 +9,14 @@
     #define uint64_t unsigned long long
     #define uint32_t unsigned long
     #define uintptr_t unsigned long
+    #define regsize_t uint32_t
 #elif __riscv_xlen == 64
     #define XLEN 64
     #define int64_t long
     #define uint64_t unsigned long
     #define uint32_t unsigned int
     #define uintptr_t unsigned long
+    #define regsize_t uint64_t
 #else
     #error Unknown xlen
 #endif

--- a/src/boot.s
+++ b/src/boot.s
@@ -349,10 +349,6 @@ interrupt_noop:
 interrupt_timer:
         j       interrupt_epilogue
 
-k_interrupt_timer:
-        call    kernel_timer_tick
-        j       interrupt_epilogue
-
 # kprintf is called with args in a0..a7, but printf expects to get fmt string
 # in a0 and a pointer to the rest of args in a1. So push a1..a7 to stack and
 # pass a pointer to that location in a1.

--- a/src/context.s
+++ b/src/context.s
@@ -1,0 +1,105 @@
+.include "src/machine-word.inc"
+.balign 4
+.section .text
+
+.globl k_interrupt_timer
+k_interrupt_timer:
+        # swap t6 and mscratch. t6 now points to trap_frame and the
+        # actual value of t6 is saved in mscratch until we can restore it a bit
+        # later:
+        csrrw   t6, mscratch, t6
+
+        # save all user registers in trap_frame:
+        sx       x1,  0, (t6)
+        sx       x2,  1, (t6)
+        sx       x3,  2, (t6)
+        sx       x4,  3, (t6)
+        sx       x5,  4, (t6)
+        sx       x6,  5, (t6)
+        sx       x7,  6, (t6)
+        sx       x8,  7, (t6)
+        sx       x9,  8, (t6)
+        sx      x10,  9, (t6)
+        sx      x11, 10, (t6)
+        sx      x12, 11, (t6)
+        sx      x13, 12, (t6)
+        sx      x14, 13, (t6)
+        sx      x15, 14, (t6)
+        sx      x16, 15, (t6)
+        sx      x17, 16, (t6)
+        sx      x18, 17, (t6)
+        sx      x19, 18, (t6)
+        sx      x20, 19, (t6)
+        sx      x21, 20, (t6)
+        sx      x22, 21, (t6)
+        sx      x23, 22, (t6)
+        sx      x24, 23, (t6)
+        sx      x25, 24, (t6)
+        sx      x26, 25, (t6)
+        sx      x27, 26, (t6)
+        sx      x28, 27, (t6)
+        sx      x29, 28, (t6)
+        sx      x30, 29, (t6)
+
+        # x31 is the same as t6, so store it below with a bit of juggling:
+        mv      a0, t6
+        csrrw   t6, mscratch, t6
+        sx      t6, 30, (a0)
+
+        # kernel_timer_tick will run the scheduler and will have populated
+        # trap_frame with the context of the target user process.
+        # ret_to_user will restore the registers from it.
+        call    kernel_timer_tick
+
+        # This will restore user registers from trap_frame and then mret:
+        j       ret_to_user
+
+.globl ret_to_user
+ret_to_user:
+        # load a pointer to trap_frame into t6:
+        la      t6, trap_frame
+        # now restore user's t6 to t6:
+        lx      t6, 30, (t6)
+        # and now the trick: swap user's t6 with mscratch, which also contains the
+        # address of trap_frame. Now t6 is the pointer again and mscratch
+        # preserves the value of user t6 until we can swap them back:
+        csrrw   t6, mscratch, t6
+
+        # now we're ready to restore all registers from trap_frame:
+        lx       x1,  0, (t6)
+        lx       x2,  1, (t6)
+        lx       x3,  2, (t6)
+        lx       x4,  3, (t6)
+        lx       x5,  4, (t6)
+        lx       x6,  5, (t6)
+        lx       x7,  6, (t6)
+        lx       x8,  7, (t6)
+        lx       x9,  8, (t6)
+        lx      x10,  9, (t6)
+        lx      x11, 10, (t6)
+        lx      x12, 11, (t6)
+        lx      x13, 12, (t6)
+        lx      x14, 13, (t6)
+        lx      x15, 14, (t6)
+        lx      x16, 15, (t6)
+        lx      x17, 16, (t6)
+        lx      x18, 17, (t6)
+        lx      x19, 18, (t6)
+        lx      x20, 19, (t6)
+        lx      x21, 20, (t6)
+        lx      x22, 21, (t6)
+        lx      x23, 22, (t6)
+        lx      x24, 23, (t6)
+        lx      x25, 24, (t6)
+        lx      x26, 25, (t6)
+        lx      x27, 26, (t6)
+        lx      x28, 27, (t6)
+        lx      x29, 28, (t6)
+        lx      x30, 29, (t6)
+
+        # x31 is the same as t6, restore it from mscratch, and mscratch will
+        # again preserve trap_frame for the next interrupt:
+        csrrw   t6, mscratch, t6
+
+        # return to userland:
+        mret

--- a/src/kernel.c
+++ b/src/kernel.c
@@ -24,6 +24,7 @@ void kinit(uintptr_t fdt_header_addr) {
     void *p = (void*)0xf10a; // this is a random hex to test out %p in kprintf()
     kprintf("kprintf test several params: %s, %p, %d\n", str, p, cpu_id);
     init_process_table();
+    init_global_trap_frame();
     set_timer_after(KERNEL_SCHEDULER_TICK_TIME);
     enable_interrupts();
     release(&init_lock);

--- a/src/proc.c
+++ b/src/proc.c
@@ -3,6 +3,7 @@
 process_t proc_table[MAX_PROCS];
 int curr_proc = 0;
 int num_procs = 0;
+trap_frame_t trap_frame;
 
 void init_process_table() {
     init_test_processes();
@@ -12,6 +13,10 @@ void init_process_table() {
     // know that so we can discard the kernel code pc that we get on that first
     // call.
     curr_proc = -1;
+}
+
+void init_global_trap_frame() {
+    set_mscratch(&trap_frame);
 }
 
 // 3.1.7 Privilege and Global Interrupt-Enable Stack in mstatus register
@@ -36,13 +41,29 @@ void init_process_table() {
 // schedule_user_process() is only called from kernel_timer_tick(), and MRET is
 // called in interrupt_epilogue, after kernel_timer_tick() exits.
 void schedule_user_process() {
-    curr_proc++;
+    if (curr_proc < 0) {
+        // compensate for curr_proc being initialized to -1 for the benefit of
+        // identifying the very first kernel_timer_tick(), which gets a mepc
+        // pointing to the kernel land, which we want to discard.
+        curr_proc = 0;
+    }
     if (num_procs == 0) {
         return;
     }
+    process_t *last_proc = &proc_table[curr_proc];
+    curr_proc++;
     if ((curr_proc >= MAX_PROCS) || (curr_proc >= num_procs)) {
         curr_proc = 0;
     }
-    set_jump_address(proc_table[curr_proc].pc);
+    process_t *proc = &proc_table[curr_proc];
+    if (last_proc->pid != proc->pid) {
+        // the user process has changed: save the descending process's context
+        // and load the ascending one's
+        for (int i = 0; i < 32; i++) {
+            last_proc->context.regs[i] = trap_frame.regs[i];
+            trap_frame.regs[i] = proc->context.regs[i];
+        }
+    }
+    set_jump_address(proc->pc);
     set_user_mode();
 }

--- a/src/proc_test.c
+++ b/src/proc_test.c
@@ -10,6 +10,12 @@ void init_test_processes() {
     num_procs = 2;
     proc_table[0].pid = 0;
     proc_table[0].pc = user_entry_point;
+    // For now, initialize userland stacks to hardcoded locations within the
+    // stack space: proc[0] will have its stack 128*XLEN_BYTES above
+    // stack_bottom
+    proc_table[0].context.regs[REG_SP] = (regsize_t)(&stack_bottom + 128);
     proc_table[1].pid = 1;
     proc_table[1].pc = user_entry_point2;
+    // proc[1] will have its stack 128*XLEN_BYTES above proc[0]'s stack
+    proc_table[1].context.regs[REG_SP] = (regsize_t)(&stack_bottom + 256);
 }

--- a/src/riscv.c
+++ b/src/riscv.c
@@ -100,3 +100,11 @@ void set_user_mode() {
     mstatus |= MODE_U;      // set them to user mode
     set_mstatus(mstatus);
 }
+
+void set_mscratch(void* ptr) {
+    asm volatile (
+        "csrw mscratch, %0"
+        :            // no output
+        : "r"(ptr)   // input in value
+    );
+}

--- a/src/userland.c
+++ b/src/userland.c
@@ -45,14 +45,14 @@ int _userland u_main() {
     int counter = 0;
     int flipper = 0;
     char pidstr[2];
+    uint32_t pid = getpid();
+    pidstr[0] = '0' + (char)pid;
     pidstr[1] = 0;
     while (1) {
         counter++;
         if (counter % PRINT_FREQ == 0) {
             flipper++;
             if ((flipper & 1) == 0) {
-                uint32_t pid = getpid();
-                pidstr[0] = '0' + (char)pid;
                 sys_puts(pidstr);
             } else {
                 sys_puts("|");
@@ -103,14 +103,14 @@ int _userland u_main2() {
     int counter = 0;
     int flipper = 0;
     char pidstr[2];
+    uint32_t pid = getpid();
+    pidstr[0] = '0' + (char)pid;
     pidstr[1] = 0;
     while (1) {
         counter++;
         if (counter % PRINT_FREQ == 0) {
             flipper++;
             if ((flipper & 1) == 0) {
-                uint32_t pid = getpid();
-                pidstr[0] = '0' + (char)pid;
                 sys_puts(pidstr);
             } else {
                 sys_puts("o");


### PR DESCRIPTION
Most significantly (for now), this allows each userland process to have
its own stack. The change in userland.c demonstrates that: we now call
`getpid()` once before the loop and store it in a stack variable.