### PR TITLE
Add paged memory allocations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ TEST_DEPS = src/baremetal-fib.s src/baremetal-print.s src/baremetal-poweroff.s
 USER_DEPS = src/boot.s src/baremetal-print.s \
 			src/baremetal-poweroff.s src/userland.c src/kernel.c src/syscalls.c \
 			src/pmp.c src/riscv.c src/fdt.c src/string.c src/proc_test.c \
-			src/spinlock.c src/proc.c src/usyscalls.s
+			src/spinlock.c src/proc.c src/usyscalls.s src/pagealloc.c
 TEST_SIFIVE_U_DEPS = $(TEST_DEPS)
 USER_SIFIVE_U_DEPS = $(USER_DEPS)
 TEST_SIFIVE_E_DEPS = $(TEST_DEPS)
@@ -203,6 +203,7 @@ $(OUT)/user_hifive1_revb: ${USER_SIFIVE_E32_DEPS}
 	$(RISCV64_GCC) -march=rv32imac -mabi=ilp32 $(GCC_FLAGS) \
 		-Wl,--defsym,ROM_START=0x20010000 -Wa,--defsym,UART=0x10013000 \
 		-Wa,--defsym,XLEN=32 -Wa,--defsym,NO_S_MODE=1 -Wa,--defsym,NUM_HARTS=1 \
+		-Wl,--defsym,RAM_SIZE=0x4000 \
 		-include include/machine/hifive1-revb.h \
 		${USER_SIFIVE_E32_DEPS} -o $@
 

--- a/include/pagealloc.h
+++ b/include/pagealloc.h
@@ -1,0 +1,34 @@
+#ifndef _PAGEALLOC_H_
+#define _PAGEALLOC_H_
+
+#include "spinlock.h"
+
+#define PAGE_SIZE           512 // bytes
+
+// Let's hardcode it for now. Make it small enough to fit in HiFive1 (32 pages
+// * 512 bytes = 16k RAM).
+#define MAX_PAGES           32
+
+#define PAGE_FREE           0
+#define PAGE_ALLOCATED      1
+
+// Describes a single page of memory. Has a pointer to the actual piece of
+// memory and flags with the status.
+typedef struct page_s {
+    void *ptr;
+    uint32_t flags;
+} page_t;
+
+// Contains all pages. Lock should be acquired to modify anything in this
+// struct.
+typedef struct paged_mem_s {
+    spinlock lock;
+    page_t pages[MAX_PAGES];
+    uint32_t num_pages;
+} paged_mem_t;
+
+void init_paged_memory();
+void* allocate_page();
+void release_page(void *ptr);
+
+#endif // ifndef _PAGEALLOC_H_

--- a/include/sys.h
+++ b/include/sys.h
@@ -9,12 +9,14 @@
     #define uint64_t unsigned long long
     #define uint32_t unsigned long
     #define uintptr_t unsigned long
+    #define regsize_t uint32_t
 #elif __riscv_xlen == 64
     #define XLEN 64
     #define int64_t long
     #define uint64_t unsigned long
     #define uint32_t unsigned int
     #define uintptr_t unsigned long
+    #define regsize_t uint64_t
 #else
     #error Unknown xlen
 #endif

--- a/src/baremetal.ld
+++ b/src/baremetal.ld
@@ -3,6 +3,8 @@ ENTRY( _start )
 SECTIONS
 {
   RAM_START = DEFINED(RAM_START) ? RAM_START : 0x80000000;
+  /* Default to 16MiB of RAM if not specified otherwise: */
+  RAM_SIZE = DEFINED(RAM_SIZE) ? RAM_SIZE : 0x1000000;
   STACK_SIZE = DEFINED(STACK_SIZE) ? STACK_SIZE : 0x1000;
   PAGE_SIZE = 0x1000;
 
@@ -22,6 +24,7 @@ SECTIONS
   .gnu_build_id : { *(.note.gnu.build-id) }
 
   . = DEFINED(ROM_START) ? RAM_START : .;
+  data_start = .;
   .data : { *(.data) }
   bss_start = .;
   .bss : {

--- a/src/kernel.c
+++ b/src/kernel.c
@@ -3,6 +3,7 @@
 #include "spinlock.h"
 #include "proc.h"
 #include "fdt.h"
+#include "pagealloc.h"
 
 spinlock init_lock = 0;
 
@@ -23,6 +24,7 @@ void kinit(uintptr_t fdt_header_addr) {
     char const* str = "foo"; // this is a random string to test out %s in kprintf()
     void *p = (void*)0xf10a; // this is a random hex to test out %p in kprintf()
     kprintf("kprintf test several params: %s, %p, %d\n", str, p, cpu_id);
+    init_paged_memory();
     init_process_table();
     set_timer_after(KERNEL_SCHEDULER_TICK_TIME);
     enable_interrupts();

--- a/src/pagealloc.c
+++ b/src/pagealloc.c
@@ -1,0 +1,66 @@
+#include "pagealloc.h"
+#include "kernel.h"
+
+paged_mem_t paged_memory;
+
+// defined in baremetal.ld:
+extern void* data_start;
+extern void* RAM_START;
+extern void* RAM_SIZE;
+
+void init_paged_memory() {
+    regsize_t ram_start = (regsize_t)&RAM_START;
+    regsize_t ram_size = (regsize_t)&RAM_SIZE;
+    regsize_t paged_mem_start = (regsize_t)&stack_top;
+    regsize_t paged_mem_end = ram_start + ram_size;
+    paged_memory.lock = 0;
+    regsize_t mem = paged_mem_start;
+    // up-align at page size to avoid the last page being incomplete:
+    mem &= ~(PAGE_SIZE - 1);
+    if (paged_mem_start > mem) {
+        mem += PAGE_SIZE;
+    }
+    int i = 0;
+    while (mem < paged_mem_end && i < MAX_PAGES) {
+        paged_memory.pages[i].ptr = (void*)mem;
+        paged_memory.pages[i].flags = PAGE_FREE;
+        mem += PAGE_SIZE;
+        i++;
+    }
+    paged_memory.num_pages = i;
+    kprintf("paged memory: start=%p, end=%p, npages=%d\n",
+            paged_mem_start, paged_mem_end, paged_memory.num_pages);
+}
+
+void* allocate_page() {
+    acquire(&paged_memory.lock);
+    for (int i = 0; i < paged_memory.num_pages; i++) {
+        page_t* page = &paged_memory.pages[i];
+        if (page->flags == PAGE_FREE) {
+            page->flags = PAGE_ALLOCATED;
+            release(&paged_memory.lock);
+            return page->ptr;
+        }
+    }
+    release(&paged_memory.lock);
+    return 0;
+}
+
+void release_page(void *ptr) {
+    acquire(&paged_memory.lock);
+    for (int i = 0; i < paged_memory.num_pages; i++) {
+        page_t* page = &paged_memory.pages[i];
+        if (page->ptr == ptr) {
+            if (page->flags == PAGE_FREE) {
+                release(&paged_memory.lock);
+                // TODO: panic here: release of an unallocated page
+                return;
+            }
+            page->flags = PAGE_FREE;
+            release(&paged_memory.lock);
+            return;
+        }
+    }
+    release(&paged_memory.lock);
+    // TODO: panic here: can't find such page
+}

--- a/testdata/want-output-u32.txt
+++ b/testdata/want-output-u32.txt
@@ -3,6 +3,7 @@ Reading FDT...
 FDT ok
 bootargs: dry-run
 kprintf test several params: foo, 0xF10A, 0
+paged memory: start=0x80004380, end=0x81000000, npages=32
 cpu parked: 1
 KKKK
 qemu-launcher: killing qemu due to timeout

--- a/testdata/want-output-u64.txt
+++ b/testdata/want-output-u64.txt
@@ -3,6 +3,7 @@ Reading FDT...
 FDT ok
 bootargs: dry-run
 kprintf test several params: foo, 0xF10A, 0
+paged memory: start=0x800044C8, end=0x81000000, npages=32
 cpu parked: 1
 KKKK
 qemu-launcher: killing qemu due to timeout


### PR DESCRIPTION
Break all the memory above stack into pages and keep track of them. The
page table is fixed at 32 pages for now, as we're severely limited by the
small HiFive1 RAM size. This should not be a problem for quite a long
time, not until we try to run some actual userland programs.