### PR TITLE
Add debug flags to all user_* targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -132,70 +132,38 @@ GCC_FLAGS=-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles \
           -fno-plt -fno-pic \
           -Tsrc/baremetal.ld -Iinclude
 
-$(OUT)/test_sifive_u: ${TEST_SIFIVE_U_DEPS}
-	$(RISCV64_GCC) -march=rv64g -mabi=lp64 $(GCC_FLAGS) \
-		${TEST_SIFIVE_U_DEPS} -o $@
-
 $(OUT)/user_sifive_u: ${USER_SIFIVE_U_DEPS}
 	$(RISCV64_GCC) -march=rv64g -mabi=lp64 $(GCC_FLAGS) \
-		-Wa,--defsym,NUM_HARTS=2 \
+		-Wa,--defsym,NUM_HARTS=2 -g \
 		-include include/machine/qemu.h \
 		${USER_SIFIVE_U_DEPS} -o $@
-
-$(OUT)/test_sifive_u32: ${TEST_SIFIVE_U32_DEPS}
-	$(RISCV64_GCC) -march=rv32g -mabi=ilp32 $(GCC_FLAGS) \
-		-Wa,--defsym,XLEN=32 \
-		-Wa,--defsym,NUM_HARTS=1 \
-		-include include/machine/qemu.h \
-		${TEST_SIFIVE_U32_DEPS} -o $@
 
 $(OUT)/user_sifive_u32: ${USER_SIFIVE_U32_DEPS}
 	$(RISCV64_GCC) -march=rv32g -mabi=ilp32 $(GCC_FLAGS) \
 		-Wa,--defsym,XLEN=32 \
-		-Wa,--defsym,NUM_HARTS=2 \
+		-Wa,--defsym,NUM_HARTS=2 -g \
 		-include include/machine/qemu.h \
 		${USER_SIFIVE_U32_DEPS} -o $@
-
-$(OUT)/test_sifive_e: ${TEST_SIFIVE_E_DEPS}
-	$(RISCV64_GCC) -march=rv64g -mabi=lp64 $(GCC_FLAGS) \
-		-Wl,--defsym,ROM_START=0x20400000 -Wa,--defsym,UART=0x10013000 \
-		-Wa,--defsym,NUM_HARTS=1 \
-		-include include/machine/qemu.h \
-		${TEST_SIFIVE_E_DEPS} -o $@
 
 $(OUT)/user_sifive_e: ${USER_SIFIVE_E_DEPS}
 	$(RISCV64_GCC) -march=rv64g -mabi=lp64 $(GCC_FLAGS) \
 		-Wl,--defsym,ROM_START=0x20400000 -Wa,--defsym,UART=0x10013000 \
-		-Wa,--defsym,NUM_HARTS=1 \
+		-Wa,--defsym,NUM_HARTS=1 -g \
 		-include include/machine/qemu.h \
 		${USER_SIFIVE_E_DEPS} -o $@
-
-$(OUT)/test_sifive_e32: ${TEST_SIFIVE_E32_DEPS}
-	$(RISCV64_GCC) -march=rv32g -mabi=ilp32 $(GCC_FLAGS) \
-		-Wl,--defsym,ROM_START=0x20400000 -Wa,--defsym,UART=0x10013000 \
-		-Wa,--defsym,XLEN=32 \
-		-Wa,--defsym,NUM_HARTS=1 \
-		-include include/machine/qemu.h \
-		${TEST_SIFIVE_E32_DEPS} -o $@
 
 $(OUT)/user_sifive_e32: ${USER_SIFIVE_E32_DEPS}
 	$(RISCV64_GCC) -march=rv32g -mabi=ilp32 $(GCC_FLAGS) \
 		-Wl,--defsym,ROM_START=0x20400000 -Wa,--defsym,UART=0x10013000 \
 		-Wa,--defsym,XLEN=32 \
-		-Wa,--defsym,NUM_HARTS=1 \
+		-Wa,--defsym,NUM_HARTS=1 -g \
 		-include include/machine/qemu.h \
 		${USER_SIFIVE_E32_DEPS} -o $@
-
-$(OUT)/test_virt: ${TEST_VIRT_DEPS}
-	$(RISCV64_GCC) -march=rv64g -mabi=lp64 $(GCC_FLAGS) \
-		-Wa,--defsym,UART=0x10000000 -Wa,--defsym,QEMU_EXIT=0x100000 \
-		-include include/machine/qemu.h \
-		${TEST_VIRT_DEPS} -o $@
 
 $(OUT)/user_virt: ${USER_VIRT_DEPS}
 	$(RISCV64_GCC) -march=rv64g -mabi=lp64 $(GCC_FLAGS) \
 		-Wa,--defsym,UART=0x10000000 -Wa,--defsym,QEMU_EXIT=0x100000 \
-		-Wa,--defsym,NUM_HARTS=1 \
+		-Wa,--defsym,NUM_HARTS=1 -g \
 		-include include/machine/qemu.h \
 		${USER_VIRT_DEPS} -o $@
 
@@ -205,6 +173,38 @@ $(OUT)/user_hifive1_revb: ${USER_SIFIVE_E32_DEPS}
 		-Wa,--defsym,XLEN=32 -Wa,--defsym,NO_S_MODE=1 -Wa,--defsym,NUM_HARTS=1 \
 		-include include/machine/hifive1-revb.h \
 		${USER_SIFIVE_E32_DEPS} -o $@
+
+$(OUT)/test_sifive_u: ${TEST_SIFIVE_U_DEPS}
+	$(RISCV64_GCC) -march=rv64g -mabi=lp64 $(GCC_FLAGS) \
+		${TEST_SIFIVE_U_DEPS} -o $@
+
+$(OUT)/test_sifive_u32: ${TEST_SIFIVE_U32_DEPS}
+	$(RISCV64_GCC) -march=rv32g -mabi=ilp32 $(GCC_FLAGS) \
+		-Wa,--defsym,XLEN=32 \
+		-Wa,--defsym,NUM_HARTS=1 \
+		-include include/machine/qemu.h \
+		${TEST_SIFIVE_U32_DEPS} -o $@
+
+$(OUT)/test_sifive_e: ${TEST_SIFIVE_E_DEPS}
+	$(RISCV64_GCC) -march=rv64g -mabi=lp64 $(GCC_FLAGS) \
+		-Wl,--defsym,ROM_START=0x20400000 -Wa,--defsym,UART=0x10013000 \
+		-Wa,--defsym,NUM_HARTS=1 \
+		-include include/machine/qemu.h \
+		${TEST_SIFIVE_E_DEPS} -o $@
+
+$(OUT)/test_sifive_e32: ${TEST_SIFIVE_E32_DEPS}
+	$(RISCV64_GCC) -march=rv32g -mabi=ilp32 $(GCC_FLAGS) \
+		-Wl,--defsym,ROM_START=0x20400000 -Wa,--defsym,UART=0x10013000 \
+		-Wa,--defsym,XLEN=32 \
+		-Wa,--defsym,NUM_HARTS=1 \
+		-include include/machine/qemu.h \
+		${TEST_SIFIVE_E32_DEPS} -o $@
+
+$(OUT)/test_virt: ${TEST_VIRT_DEPS}
+	$(RISCV64_GCC) -march=rv64g -mabi=lp64 $(GCC_FLAGS) \
+		-Wa,--defsym,UART=0x10000000 -Wa,--defsym,QEMU_EXIT=0x100000 \
+		-include include/machine/qemu.h \
+		${TEST_VIRT_DEPS} -o $@
 
 $(OUT):
 	mkdir -p $(OUT)

--- a/scripts/qemu-launcher.py
+++ b/scripts/qemu-launcher.py
@@ -69,7 +69,7 @@ def write_gdb_files(binary, is_32bit, is_multicore):
             f.write('inferior 2\n')
             f.write('attach 2\n')
             f.write('set schedule-multiple\n')
-            f.write('set scheduler-locking on\n')
+            # f.write('set scheduler-locking on\n')
             f.write('thread 1.1\n')
 
 


### PR DESCRIPTION
And group all test_* targets at the end of makefile for easier
navigations between the targets.

Also disable scheduler-locking by default. It's indispensable when
debugging early boot code, but an annoying nuisance in all other cases.
So let's have it handy but commented out by default.