### PR TITLE
Fix an outrageous bug trashing the stack

### DIFF
--- a/src/usyscalls.s
+++ b/src/usyscalls.s
@@ -10,17 +10,17 @@
 .globl sys_puts
 sys_puts:
         stackalloc_x 1
-        sx      ra, 1, (sp)
+        sx      ra, 0, (sp)
         macro_syscall 4
-        lx      ra, 1, (sp)
+        lx      ra, 0, (sp)
         stackfree_x 1
         ret
 
 .globl getpid
 getpid:
         stackalloc_x 1
-        sx      ra, 1, (sp)
+        sx      ra, 0, (sp)
         macro_syscall 20
-        lx      ra, 1, (sp)
+        lx      ra, 0, (sp)
         stackfree_x 1
         ret


### PR DESCRIPTION
In the syscalls code I was writing return address to the wrong offset,
thus trashing whatever was in that stack location. Looks like the bug
was lurking here for a year since the very first introduction of this
code, and surviving all modifications:

https://github.com/rtfb/riscv64-in-qemu/commit/83543b7fba82b51eb8198dfa6afcbf93ced69b4f
https://github.com/rtfb/riscv64-in-qemu/commit/279c3cceb85a4d5ea770fa03f92e0118f2f92cc6
https://github.com/rtfb/riscv64-in-qemu/commit/e7aa82a0dd3f2c0e204901f809ea232936e7c74c

Even more hilarious is that the bug didn't manifest itself for so long.
Our userland programs are so simple yet, using so little stack, that the
bug is not observable even now, I discovered it in WIP code working on
another syscall.